### PR TITLE
Add Dockerfile for building documentation with drone

### DIFF
--- a/documentation/Dockerfile
+++ b/documentation/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian
+RUN apt-get update && apt-get install -y python-pil python-sphinx \ 
+    python-sphinxcontrib.phpdomain rst2pdf texlive-fonts-recommended \
+    texlive-latex-extra texlive-latex-recommended make


### PR DESCRIPTION
Dockerfile for automated documentation builds with drone

related to https://github.com/nextcloud/documentation/issues/3