### PR TITLE
Add PHP 7.1 docker

### DIFF
--- a/php7.1/Dockerfile
+++ b/php7.1/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos
+
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+RUN yum install -y yum-utils
+RUN yum-config-manager --enable remi-php71
+RUN yum -y update
+RUN yum install -y php71.x86_64 php71-php-intl.x86_64 php71-php-gd.x86_64 php71-php-cli.x86_64 php71-php-pecl-imagick.x86_64 php71-php-pgsql.x86_64 php71-php-mcrypt.x86_64 php71-php-ldap.x86_64 php71-php-pecl-apcu.x86_64 php71-php-pecl-redis.x86_64  php71-php-pecl-mysql.x86_64 php71-php-pecl-zip.x86_64 php71-php-xml.x86_64 php71-php-mbstring.x86_64 php71-php-process.x86_64 php71-php-pecl-xdebug.x86_64 git curl which
+RUN ln -s /usr/bin/php71 /usr/bin/php
+RUN curl -O -L https://phar.phpunit.de/phpunit-5.4.6.phar \
+    && chmod +x phpunit-5.4.6.phar \
+    && mv phpunit-5.4.6.phar /usr/local/bin/phpunit
+RUN curl -O -L https://getcomposer.org/download/1.1.2/composer.phar \
+    && chmod +x composer.phar \
+    && mv composer.phar /usr/local/bin/composer
+ADD nextcloud.ini /etc/opt/remi/php71/php.d/nextcloud.ini

--- a/php7.1/nextcloud.ini
+++ b/php7.1/nextcloud.ini
@@ -1,0 +1,1 @@
+memory_limit = 768M


### PR DESCRIPTION
At the moment this is failing hard since our code is unfortunately not yet PHP 7.1 compatible :-) - But autotest.sh can be executed.

Fixes https://github.com/nextcloud/docker-ci/issues/10

cc @MorrisJobke @rullzer 