### PR TITLE
revert to sys-img-armeabi-v7a-android-24

### DIFF
--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -1,6 +1,6 @@
 FROM jacekmarchwicki/android:java8-r24-4-1
 
-RUN cd /opt && /opt/tools/android-accept-licenses.sh "android-sdk-linux/tools/android update sdk --all --no-ui --filter sys-img-x86-android-24"
+RUN cd /opt && /opt/tools/android-accept-licenses.sh "android-sdk-linux/tools/android update sdk --all --no-ui --filter sys-img-armeabi-v7a-android-24"
 
 RUN apt-get update && apt-get install -y libxdamage1 libxfixes3 libpulse0 && apt-get clean
 


### PR DESCRIPTION
cc @MorrisJobke as discussed move back to sys-img-armeabi-v7a-android-24 instead of x86 