### PR TITLE
Add image for Nextcloud server used in acceptance tests

### DIFF
--- a/acceptance-nextcloud-server-php7.1-apache/Dockerfile
+++ b/acceptance-nextcloud-server-php7.1-apache/Dockerfile
@@ -1,0 +1,75 @@
+# This Dockerfile builds an image of a system in which a Nextcloud server could
+# be installed. It is based on the Dockerfile for Nextcloud 11 on Apache
+# (https://github.com/nextcloud/docker/blob/843d309ee62b9d2704e6141d2103f9ded97e35b6/11.0/apache/Dockerfile),
+# although without the download and copy of a specific Nextcloud version; there
+# is no volume either at "/var/www/html" as it offers no value for its intended
+# use case as a Drone service. As such, it provides a remote control system for
+# the Nextcloud server (for example, to reset it), including a helper script to
+# setup the Nextcloud server as needed from the Git repository cloned by Drone.
+
+FROM php:7.1-apache
+
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  libcurl4-openssl-dev \
+  libfreetype6-dev \
+  libicu-dev \
+  libjpeg-dev \
+  libldap2-dev \
+  libmcrypt-dev \
+  libmemcached-dev \
+  libpng12-dev \
+  libpq-dev \
+  libxml2-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# https://docs.nextcloud.com/server/9/admin_manual/installation/source_installation.html
+RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu \
+  && docker-php-ext-install gd exif intl mbstring mcrypt ldap mysqli opcache pdo_mysql pdo_pgsql pgsql zip
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.enable_cli=1'; \
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN a2enmod rewrite
+
+# PECL extensions
+RUN set -ex \
+ && pecl install APCu-5.1.8 \
+ && pecl install memcached-3.0.2 \
+ && pecl install redis-3.1.1 \
+ && docker-php-ext-enable apcu redis memcached
+RUN a2enmod rewrite
+
+# php-sockets is needed by Nextcloud server control
+RUN docker-php-ext-install sockets
+
+# Add Git to be able to restore "/var/www/html/" to a saved state
+RUN apt-get update && apt-get install -y \
+  git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Configure Apache to listen on a non-privileged port so it can be started by
+# "www-data" user in "nextcloud-server-control.php"
+RUN sed --in-place "s/Listen 80/Listen 8000/" /etc/apache2/ports.conf \
+  && sed --in-place "s/<VirtualHost \*:80>/<VirtualHost \*:8000>/" /etc/apache2/sites-enabled/000-default.conf
+
+# Unlink the logs from stdout and stderr set by the parent Dockerfile, as in
+# this image the user running Apache may not be the same as the user running the
+# container (and Apache would refuse to start if it was not able to write to the
+# logs)
+RUN set -ex \
+  && . "$APACHE_ENVVARS" \
+  && unlink "$APACHE_LOG_DIR/error.log" \
+  && unlink "$APACHE_LOG_DIR/access.log" \
+  && unlink "$APACHE_LOG_DIR/other_vhosts_access.log"
+
+COPY nextcloud-server-control.php /usr/local/bin/
+COPY nextcloud-server-control-setup.sh /usr/local/bin/

--- a/acceptance-nextcloud-server-php7.1-apache/nextcloud-server-control-setup.sh
+++ b/acceptance-nextcloud-server-php7.1-apache/nextcloud-server-control-setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# @copyright Copyright (c) 2017, Daniel Calviño Sánchez (danxuliu@gmail.com)
+#
+# @license GNU AGPL version 3 or any later version
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Helper script to set up the system as expected by the Nextcloud server control
+# and the acceptance tests.
+#
+# The Nextcloud server is copied to "/var/www/html" from the Git repository
+# cloned by Drone. Once installed and configured as expected by the acceptance
+# tests, a new Git repository is created in "/var/www/html" and a snapshot of
+# the whole directory (no ".gitignore" file is used) is saved to the repository;
+# thanks to this, the Nextcloud server control can reset the server to its
+# default state when needed.
+#
+# When running this script the working directory must be the Git repository
+# cloned by Drone; the user must be root.
+
+# Exit immediately on errors.
+set -o errexit
+
+echo "Copy Nextcloud server to \"var/www/html\" from the Git repository cloned by Drone"
+NEXTCLOUD_TAR="$(mktemp --tmpdir="${TMPDIR:-/tmp}" --suffix=.tar nextcloud-XXXXXXXXXX)"
+
+tar --create --file="$NEXTCLOUD_TAR" --exclude=".git" --exclude=".gitignore" --exclude="./build" --exclude="./config/config.php" --exclude="./data" --exclude="./tests" .
+tar --append --file="$NEXTCLOUD_TAR" build/acceptance/installAndConfigureServer.sh
+
+cd /var/www/html
+tar --extract --file="$NEXTCLOUD_TAR"
+rm "$NEXTCLOUD_TAR"
+
+chown -R www-data:www-data /var/www/html/
+
+echo "Install and configure Nextcloud server"
+su --shell "/bin/sh" --command "cd /var/www/html/ && build/acceptance/installAndConfigureServer.sh" - www-data
+
+echo "Save the default state so Nextcloud server control can reset to it"
+su --shell "/bin/sh" --command "cd /var/www/html/ && git init && git add --all && echo 'Default state' | git -c user.name='John Doe' -c user.email='john@doe.org' commit --quiet --file=-" - www-data

--- a/acceptance-nextcloud-server-php7.1-apache/nextcloud-server-control.php
+++ b/acceptance-nextcloud-server-php7.1-apache/nextcloud-server-control.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * The Nextcloud server control is used by the acceptance tests to remotely
+ * control the Nextcloud server.
+ *
+ * The acceptance tests need to perform certain operations in the Nextcloud
+ * server that require access to the system it is running on, like resetting the
+ * server to a default state. The Nextcloud server control is used in those
+ * cases in which the acceptance tests do not have access to the system, like
+ * when running in Drone.
+ *
+ * In order to use the Nextcloud server control the system must be set up in a
+ * specific way: the Nextcloud server must be installed in "/var/www/html",
+ * using local data storage, and a snapshot of the whole "/var/www/html"
+ * directory (no ".gitignore" file is used) in its default state must be stored
+ * in a Git repository, also in "/var/www/html". Moreover, the same user that
+ * runs Nextcloud server control must be able to reset the Git repository and
+ * execute "/usr/sbin/apache2ctl" (thus, if Nextcloud server control is run as
+ * a user like "www-data", Apache must be configured to listen on a
+ * non-privileged port).
+ */
+
+namespace NextcloudServerControl {
+
+class SocketException extends \Exception {
+	public function __construct($message) {
+		parent::__construct($message);
+	}
+}
+
+/**
+ * Common class for communication between client and server.
+ *
+ * Clients and server communicate through messages: a client sends a request and
+ * the server answers with a response. Requests and responses all have the same
+ * common structure composed by a mandatory header and optional data. The header
+ * contains a code that identifies the type of request or response followed by
+ * the length of the data (which can be 0). The data is a free form string that
+ * depends on each request and response type.
+ *
+ * The Messenger abstracts all that and provides two public methods: readMessage
+ * and writeMessage. For each connection a client first writes the request
+ * message and then reads the response message, while the server first reads the
+ * request message and then writes the response message. If the client needs to
+ * send another request it must connect again to the server.
+ *
+ * The Messenger class in the server must be kept in sync with the Messenger
+ * class in the client. Due to the size of the code and its current use it was
+ * more practical, at least for the time being, to keep two copies of the code
+ * than creating a library that had to be downloaded and included in the client
+ * and in the server.
+ */
+class Messenger {
+
+	/**
+	 * Reset the Nextcloud server.
+	 *
+	 * -Request data: empty
+	 * -OK response data: empty.
+	 * -Failed response data: error information.
+	 */
+	const CODE_REQUEST_RESET = 0;
+
+	const CODE_RESPONSE_OK = 0;
+	const CODE_RESPONSE_FAILED = 1;
+
+	const HEADER_LENGTH = 5;
+
+	/**
+	 * Reads a message from the given socket.
+	 *
+	 * The message is returned as an indexed array with keys "code" and "data".
+	 *
+	 * @param resource $socket the socket to read the message from.
+	 * @return array the message read.
+	 * @throws SocketException if an error occurs while reading the socket.
+	 */
+	public static function readMessage($socket) {
+		$header = self::readSocket($socket, self::HEADER_LENGTH);
+		$header = unpack("Ccode/VdataLength", $header);
+
+		$data = self::readSocket($socket, $header["dataLength"]);
+
+		return [ "code" => $header["code"], "data" => $data ];
+	}
+
+	/**
+	 * Reads content from the given socket.
+	 *
+	 * It blocks until the specified number of bytes were read.
+	 *
+	 * @param resource $socket the socket to read the message from.
+	 * @param int $length the number of bytes to read.
+	 * @return string the content read.
+	 * @throws SocketException if an error occurs while reading the socket.
+	 */
+	private static function readSocket($socket, $length) {
+		if ($socket == null) {
+			throw new SocketException("Null socket can not be read from");
+		}
+
+		$pendingLength = $length;
+		$content = "";
+
+		while ($pendingLength > 0) {
+			$readContent = socket_read($socket, $pendingLength);
+			if ($readContent === "") {
+				throw new SocketException("Socket could not be read: $pendingLength bytes are pending, but there is no more data to read");
+			} else if ($readContent == false) {
+				throw new SocketException("Socket could not be read: " . socket_strerror(socket_last_error()));
+			}
+
+			$pendingLength -= strlen($readContent);
+			$content = $content . $readContent;
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Writes a message to the given socket.
+	 *
+	 * @param resource $socket the socket to write the message to.
+	 * @param int $code the message code.
+	 * @param string $data the message data, if any.
+	 * @throws SocketException if an error occurs while reading the socket.
+	 */
+	public static function writeMessage($socket, $code, $data = "") {
+		if ($socket == null) {
+			throw new SocketException("Null socket can not be written to");
+		}
+
+		$header = pack("CV", $code, strlen($data));
+
+		$message = $header . $data;
+		$pendingLength = strlen($message);
+
+		while ($pendingLength > 0) {
+			$sent = socket_write($socket, $message, $pendingLength);
+			if ($sent !== 0 && $sent == false) {
+				throw new SocketException("Message ($message) could not be written: " . socket_strerror(socket_last_error()));
+			}
+
+			$pendingLength -= $sent;
+			$message = substr($message, $sent);
+		}
+	}
+}
+
+class FailedRequestException extends \Exception {
+	public function __construct($message) {
+		parent::__construct($message);
+	}
+}
+
+/**
+ * Server to handle requests sent by clients.
+ */
+class Server {
+
+	/**
+	 * @var port
+	 */
+	private $port;
+
+	/**
+	 * @param int $port
+	 */
+	public function __construct($port) {
+		$this->port = $port;
+	}
+
+	/**
+	 * Main loop to listen for and handle requests.
+	 */
+	public function main() {
+		$mainSocket = socket_create_listen($this->port);
+		if ($mainSocket === false) {
+			throw new SocketException("Server socket to control Nextcloud server could not be created: " . socket_strerror(socket_last_error()));
+		}
+
+		while ($connectedSocket = socket_accept($mainSocket)) {
+			try {
+				$this->handleRequestAndSendResponse($connectedSocket);
+			} catch (SocketException $exception) {
+				echo "Error sending or receiving: " . $exception->getMessage() . "\n";
+			} finally {
+				socket_close($connectedSocket);
+			}
+		}
+
+		socket_close($mainSocket);
+	}
+
+	/**
+	 * Handles the request and sends the appropriate response.
+	 *
+	 * @param resource $socket the socket to use for communication.
+	 * @throws SocketException if an error occurs when reading from or writing
+	 *         to the socket.
+	 */
+	private function handleRequestAndSendResponse($socket) {
+		try {
+			$request = Messenger::readMessage($socket);
+
+			$responseData = $this->handleRequest($request["code"], $request["data"]);
+
+			Messenger::writeMessage($socket, Messenger::CODE_RESPONSE_OK, $responseData);
+		} catch (FailedRequestException $exception) {
+			echo "Error handling request: " . $exception->getMessage() . "\n";
+
+			Messenger::writeMessage($socket, Messenger::CODE_RESPONSE_FAILED, $exception->getMessage());
+		}
+	}
+
+	/**
+	 * Handles the request, returning the response data (if any).
+	 *
+	 * @param string $code the request code.
+	 * @param string $data the request data, if any.
+	 * @return string the response data, if any.
+	 * @throws FailedRequestException if the request can not be handled.
+	 */
+	private function handleRequest($code, $data) {
+		if ($code == Messenger::CODE_REQUEST_RESET) {
+			echo "Reset request\n";
+			return $this->handleResetRequest();
+		}
+
+		echo "Unknown request: $code\n";
+		throw new FailedRequestException("Unknown request: $code");
+	}
+
+	/**
+	 * Resets the Nextcloud server to its default state.
+	 *
+	 * If the reset succeeds an empty string is returned. If it fails, a
+	 * FailedRequestException is thrown.
+	 *
+	 * @return string empty.
+	 * @throws FailedRequestException if the reset fails.
+	 */
+	private function handleResetRequest() {
+		$this->execOrFailRequest("/usr/sbin/apache2ctl stop");
+
+		$this->execOrFailRequest("cd /var/www/html/ && git reset --hard HEAD");
+		$this->execOrFailRequest("cd /var/www/html/ && git clean -d --force");
+
+		$this->execOrFailRequest("/usr/sbin/apache2ctl start");
+
+		return "";
+	}
+
+	/**
+	 * Executes the given command, throwing a FailedRequestException if it
+	 * fails.
+	 *
+	 * @param string $command the command to execute.
+	 * @throws FailedRequestException if the command fails to execute.
+	 */
+	private function execOrFailRequest($command) {
+		exec($command . " 2>&1", $output, $returnValue);
+		if ($returnValue != 0) {
+			throw new FailedRequestException("'$command' could not be executed: " . implode("\n", $output));
+		}
+	}
+}
+
+}
+
+namespace {
+
+if (count($argv) != 2) {
+	echo "Usage: " . $argv[0] . " PORT\n";
+
+	return 1;
+}
+
+$port = $argv[1];
+
+$server = new NextcloudServerControl\Server($port);
+$server->main();
+
+}


### PR DESCRIPTION
The [acceptance test system for Nextcloud server](https://github.com/nextcloud/server/pull/4208) verifies the behaviour of an actual Nextcloud server. When run in a local development machine, the acceptance tests use Docker to create and destroy a container with a Nextcloud server for each scenario. However, due to security concerns, that approach is not valid in Drone (if Drone containers had access to Docker a malicious pull request could be used to take over the Drone server).

Instead of creating and destroying the Nextcloud server for each scenario the Nextcloud server could be run in a Drone service for each feature. However, this would mean that the Nextcloud server was shared by all the scenarios in that feature, and thus the scenarios would not be independent one from each other. To solve that this pull request adds the Dockerfile for a Drone service that, besides a base system in which install the Nextcloud server, provides a helper "daemon", the Nextcloud server control, that can be used by the acceptance tests to reset the Nextcloud server when a new scenario starts.

The Nextcloud server control is a very basic server that simply listens on certain port for requests (currently, only _reset_), executes them, and sends back a response. The reset request stops Apache, restores _/var/www/html_ (where the Nextcloud server is installed) to certain state and starts Apache again. To be able to restore it a snapshot of the whole _/var/www/html_ directory (no _.gitignore_ is used) is added to a Git repository after installing and configuring the Nextcloud server as expected by the acceptance tests; due to this reset system the Nextcloud server must use local data storage.
