### PR TITLE
Temporary fix of wrong naming of transifex

### DIFF
--- a/translations/handleAndroidTranslations.sh
+++ b/translations/handleAndroidTranslations.sh
@@ -23,6 +23,8 @@ tx pull -f -a --minimum-perc=50
 # copy transifex strings to fastlane
 app/scripts/metadata/generate_metadata.py
 
+mv src/main/res/values-es_419 src/main/res/values-es-rUS
+
 # create git commit and push it
 git add .
 git commit -am "[tx-robot] updated from transifex" || true


### PR DESCRIPTION
values-es_419 is wrong on android, although "419" is quite common for latin america.
Currently we do this via PR, but doing this until transifex fixes this, will be quite annoying.