### PR TITLE
Use Ubuntu base for the image for better dput support

### DIFF
--- a/client/Dockerfile-Debian
+++ b/client/Dockerfile-Debian
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM ubuntu:artful
 
 RUN apt-get update -q
-RUN apt-get install -y devscripts cdbs osc
+RUN apt-get install -y devscripts cdbs osc git


### PR DESCRIPTION
The Debian image does not support uploading to Launchpad PPAs, so an Ubuntu image would be better.