### PR TITLE
Add Dockerfile for acceptance tests

### DIFF
--- a/acceptance-php7.1/Dockerfile
+++ b/acceptance-php7.1/Dockerfile
@@ -1,0 +1,9 @@
+FROM nextcloudci/php7.1:php7.1-16
+
+RUN apt-get update && apt-get install -y apache2 libapache2-mod-php7.1 && \
+    apt-get autoremove -y && apt-get autoclean && apt-get clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# /var/www/html has to be linked to the root directory of the Nextcloud server
+# before the tests are run on Apache.
+RUN rm -fr /var/www/html


### PR DESCRIPTION
Acceptance tests for Nextcloud server can be run on the PHP built-in web server, so until now the Docker containers for unit or integration tests were used for the acceptance tests.

However, the PHP built-in web server is single threaded, so it can not be used to test certain apps, like for example Nextcloud Talk (as it uses long polling, and thus requires a web server that can handle several requests in parallel).

This pull request adds a new container to be used by acceptance tests; it is based on the container for unit tests (specifically, on _php7.1_... for no special reason, to be honest :-) ) and adds the Apache web server, so acceptance tests can be run on the PHP built-in web server or on the Apache web server as needed.

I will push the tag to trigger the build of the container once the pull request is merged.
