### PR TITLE
Rename locales

### DIFF
--- a/translations/handlePlainTranslations.sh
+++ b/translations/handlePlainTranslations.sh
@@ -37,6 +37,13 @@ if [ -d src/main/res ]; then
   mv src/main/res/values-de-rDE src/main/res/values-de
 fi
 
+# move language folder as java uses old locales
+if [ -d src/main/res ]; then
+  mv src/main/res/values-he src/main/res/values-iw
+  mv src/main/res/values-id src/main/res/values-in
+  mv src/main/res/values-yi src/main/res/values-ji
+fi
+
 if [ -e "scripts/metadata/generate_metadata.py" ]; then
   # copy transifex strings to fastlane
   python3 scripts/metadata/generate_metadata.py


### PR DESCRIPTION
Android lint gives us this warning:
> ../../../src/main/res/values-id: The locale folder "id" should be called "in" instead; see the java.util.Locale documentation
From the java.util.Locale documentation:
"Note that Java uses several deprecated two-letter codes. The Hebrew ("he") language code is rewritten as "iw", Indonesian ("id") as "in", and Yiddish ("yi") as "ji". This rewriting happens even if you construct your own Locale object, not just for instances returned by the various lookup methods.
>
>Because of this, if you add your localized resources in for example values-he they will not be used, since the system will look for values-iw instead.

@MorrisJobke I hope/assume that the script is still working, even if one or two value folders are not present? Only the exit code of the script is checked, or?