### PR TITLE
Fix german translation for News Android app

### DIFF
--- a/translations/handlePlainTranslations.sh
+++ b/translations/handlePlainTranslations.sh
@@ -41,6 +41,11 @@ if [ -d app/src/main/res ]; then
   rm -rf app/src/main/res/values-de
   mv app/src/main/res/values-de-rDE app/src/main/res/values-de
 fi
+# for the Android news app rename the informal german to the formal version
+if [ -d News-Android-App/src/main/res ]; then
+  rm -rf News-Android-App/src/main/res/values-de
+  mv News-Android-App/src/main/res/values-de-rDE News-Android-App/src/main/res/values-de
+fi
 
 if [ -e "scripts/metadata/generate_metadata.py" ]; then
   # copy transifex strings to fastlane


### PR DESCRIPTION
I hope the path is correct:
https://github.com/nextcloud/news-android/blob/79c899843a5bea4b6d32dd6241bb6a26cde9b54c/News-Android-App/src/main/res/values-de-rDE/strings.xml#L4
https://github.com/nextcloud/news-android/blob/79c899843a5bea4b6d32dd6241bb6a26cde9b54c/News-Android-App/src/main/res/values-de/strings.xml#L3-L2

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>