### PR TITLE
translationtool: remove unused method readIgnoreList

### DIFF
--- a/translations/translationtool/src/translationtool.php
+++ b/translations/translationtool/src/translationtool.php
@@ -61,7 +61,6 @@ class TranslatableApp {
 		$pathToPotFile = $this->translationsPath . '/templates/' . $this->name . '.pot';
 
 		// Gather required data
-		$this->readIgnoreList();
 		$this->createFakeFileForAppInfo();
 		$this->createFakeFileForVueFiles();
 		$translatableFiles = $this->findTranslatableFiles(
@@ -205,15 +204,6 @@ class TranslatableApp {
 		}
 
 		return $translatable;
-	}
-
-	private function readIgnoreList() {
-		$ignoreFile = $this->appPath . '/l10n/ignorelist';
-		if (!is_file($ignoreFile)) {
-			return [];
-		}
-
-		return file($ignoreFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
 	}
 
 	private function findLanguages() {


### PR DESCRIPTION
The method `readIgnoreList()` wasn't used properly which results in the situation, that the content of the file `/l10n/ignorelist` was completely ignored. However, `translationtool` uses `/.l10nignore` for the same purpose, see discussion in #118. Therefore, the respective code can be safely removed.

Fixes #118.