### PR TITLE
Fetch origin before checkout

### DIFF
--- a/server/init.sh
+++ b/server/init.sh
@@ -7,6 +7,7 @@ cd /var/www/html/
 
 #Update code
 su www-data -c "
+git fetch origin
 git checkout ${BRANCH}
 git pull
 git submodule update


### PR DESCRIPTION
The Dockerfile image is cached at the time of building by the docker hub. Therefore any reference created between the image build and the run of the test won't exists :)