### PR TITLE
Allow apps to specifiy custom backport branches for translations

### DIFF
--- a/translations/Dockerfile
+++ b/translations/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Morris Jobke <hey@morrisjobke.de>
 # Install python
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
+        awk \
         gettext \
         git \
         gnupg \

--- a/translations/handleAppTranslations.sh
+++ b/translations/handleAppTranslations.sh
@@ -14,6 +14,9 @@ git clone git@github.com:$1/$2 /app
 # TODO use build/l10nParseAppInfo.php to fetch app names for l10n
 
 versions='stable19 stable20 stable20.1 stable21 stable21.1 master'
+if [[ -f '/app/.tx/backport' ]]; then
+  versions="$(cat /app/.tx/backport) master"
+fi
 
 # build POT files for all versions
 mkdir stable-templates
@@ -65,7 +68,8 @@ tx push -s
 # pull translations - force pull because a fresh clone has newer time stamps
 tx pull -f -a --minimum-perc=5
 
-backportVersions='master stable21.1 stable21 stable20.1 stable20 stable19'
+# reverse version list to apply backports
+backportVersions=$(echo $versions | awk '{for(i=NF;i>=1;i--) printf "%s ", $i;print ""}')
 for version in $backportVersions
 do
   # skip if the branch doesn't exist


### PR DESCRIPTION
This will allow apps to specify custom backport branches in a .tx/backport file in their master branch that will then be used instead of the default stable14-stable16 branches.

Fixes https://github.com/nextcloud/docker-ci/issues/161