### PR TITLE
Allow more whitespace in translations

### DIFF
--- a/translations/translationtool/src/translationtool.php
+++ b/translations/translationtool/src/translationtool.php
@@ -327,8 +327,8 @@ class TranslatableApp {
 			}
 
 			// t
-			preg_match_all("/\Wt\s*\('([\w]+)',\s*'(.+)'/", $vueSource, $singleQuoteMatches);
-			preg_match_all("/\Wt\s*\(\"([\w]+)\",\s*\"(.+)\"/", $vueSource, $doubleQuoteMatches);
+			preg_match_all("/\Wt\s*\(\s*'([\w]+)',\s*'(.+)'/", $vueSource, $singleQuoteMatches);
+			preg_match_all("/\Wt\s*\(\s*\"([\w]+)\",\s*\"(.+)\"/", $vueSource, $doubleQuoteMatches);
 			preg_match_all("/\Wt\s*\(\s*\'([\w]+)\'\s*,\s*\`(.+)\`\s*\)/msU", $vueSource, $templateQuoteMatches);
 			$matches = array_merge($singleQuoteMatches[2], $doubleQuoteMatches[2], $templateQuoteMatches[2]);
 			foreach ($matches as $match) {
@@ -336,8 +336,8 @@ class TranslatableApp {
 			}
 
 			// n
-			preg_match_all("/\Wn\s*\('([\w]+)',\s*'(.+)'\s*,\s*'(.+)'\s*(.+)/", $vueSource, $singleQuoteMatches);
-			preg_match_all("/\Wn\s*\(\"([\w]+)\",\s*\"(.+)\"\s*,\s*\"(.+)\"\s*(.+)/", $vueSource, $doubleQuoteMatches);
+			preg_match_all("/\Wn\s*\(\s*'([\w]+)',\s*'(.+)'\s*,\s*'(.+)'\s*(.+)/", $vueSource, $singleQuoteMatches);
+			preg_match_all("/\Wn\s*\(\s*\"([\w]+)\",\s*\"(.+)\"\s*,\s*\"(.+)\"\s*(.+)/", $vueSource, $doubleQuoteMatches);
 			preg_match_all("/\Wn\s*\(\s*\'([\w]+)\'\s*,\s*\`(.+)\`\s*,\s*\`(.+)\`\s*\)/msU", $vueSource, $templateQuoteMatches);
 			$matches1 = array_merge($singleQuoteMatches[2], $doubleQuoteMatches[2], $templateQuoteMatches[2]);
 			$matches2 = array_merge($singleQuoteMatches[3], $doubleQuoteMatches[3], $templateQuoteMatches[3]);


### PR DESCRIPTION
This allows whitespace between the opening bracket and the first quotation mark in translations, e.g.
```
t(
    'bookmarks',
    'In order to display real screenshots of your bookmarked websites, Bookmarks can use a third-party service to generate those.'
)
```

Some more background on this: while working on the `bookmarks` app, I noticed some strings were not found by the translation tool, e.g.
https://github.com/nextcloud/bookmarks/blob/f440271d210e01fad864b03441c819bbd63217af/src/components/ViewAdmin.vue#L8
The formatting with newlines prevented the translations from being recognized and shown in Transifex.