### PR TITLE
Add Dockerfiles for tests on PHP 7.3

### DIFF
--- a/integration-php7.3/Dockerfile
+++ b/integration-php7.3/Dockerfile
@@ -1,0 +1,9 @@
+FROM nextcloudci/php7.3:php7.3-3
+
+RUN composer global require hirak/prestissimo
+
+RUN mkdir /tmp/server && \
+    cd /tmp/server && git clone --recursive https://github.com/nextcloud/server.git && \
+    cd /tmp/server/server/build/integration && composer install && \
+    cd /tmp/server/server/tests/acceptance && composer install && \
+    rm -rf /tmp/server

--- a/litmus-php7.3/Dockerfile
+++ b/litmus-php7.3/Dockerfile
@@ -1,0 +1,7 @@
+FROM nextcloudci/php7.3:php7.3-3
+RUN apt-get update && apt-get install -y gcc realpath make python && \
+    mkdir -p /tmp/litmus && \
+    wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz && \
+    cd /tmp/litmus && tar -xzf litmus-0.13.tar.gz && \
+    cd /tmp/litmus/litmus-0.13 && ./configure && make && rm -f /tmp/litmus-0.13.tar.gz && \
+    apt-get clean

--- a/php7.3-memcached/Dockerfile
+++ b/php7.3-memcached/Dockerfile
@@ -1,0 +1,10 @@
+FROM nextcloudci/php7.3:php7.3-3
+RUN apt-get update && \
+    apt-get purge -y php7.3-apcu && \
+    apt-get install -y php7.3-memcached memcached && \
+    update-rc.d memcached enable && \
+    apt-get autoremove -y && apt-get autoclean && apt-get clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+ADD nextcloud.ini /etc/php/7.3/cli/conf.d/nextcloud.ini
+ENTRYPOINT service memcached restart && bash

--- a/php7.3-memcached/nextcloud.ini
+++ b/php7.3-memcached/nextcloud.ini
@@ -1,0 +1,10 @@
+#apc.enable_cli = 1
+phar.readonly = 0 ; only for building phar files on CI - should be disabled on production environments
+; Opcache
+opcache.enable=1
+opcache.enable_cli=1
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=10000
+opcache.memory_consumption=128
+opcache.save_comments=1
+opcache.revalidate_freq=1

--- a/samba-native-php7.3/Dockerfile
+++ b/samba-native-php7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloudci/samba-non-native-php7.3:1
+FROM nextcloudci/samba-non-native-php7.3:samba-non-native-php7.3-1
 
 RUN apt update
 RUN apt-get install -y php7.3-dev libsmbclient-dev git

--- a/samba-native-php7.3/Dockerfile
+++ b/samba-native-php7.3/Dockerfile
@@ -1,0 +1,8 @@
+FROM nextcloudci/samba-non-native-php7.3:1
+
+RUN apt update
+RUN apt-get install -y php7.3-dev libsmbclient-dev git
+RUN git clone git://github.com/eduardok/libsmbclient-php.git
+RUN cd libsmbclient-php && phpize && ./configure && make && make install
+
+ADD smbclient.ini /etc/php/7.3/cli/conf.d/smbclient.ini

--- a/samba-native-php7.3/smbclient.ini
+++ b/samba-native-php7.3/smbclient.ini
@@ -1,0 +1,1 @@
+extension="smbclient.so"

--- a/samba-non-native-php7.3/Dockerfile
+++ b/samba-non-native-php7.3/Dockerfile
@@ -1,0 +1,22 @@
+# Based upon https://hub.docker.com/r/silvershell/samba/
+FROM nextcloudci/php7.3:php7.3-3
+
+ENV SMB_USER smbuser
+ENV SMB_PASSWORD smbpassword
+
+RUN apt-get update
+
+RUN apt-get install -y samba smbclient
+RUN mkdir -p /opt/samba/share
+RUN chmod 777 /opt/samba/share
+
+RUN mkdir -p /opt/samba/user
+RUN chmod 777 /opt/samba/user
+
+RUN useradd -s /bin/false "$SMB_USER"
+RUN (echo "$SMB_PASSWORD"; echo "$SMB_PASSWORD" ) | pdbedit -a -u "$SMB_USER"
+
+EXPOSE 137/udp 138/udp 139 445
+
+COPY smb.conf /etc/samba/smb.conf
+

--- a/samba-non-native-php7.3/smb.conf
+++ b/samba-non-native-php7.3/smb.conf
@@ -1,0 +1,46 @@
+[global]
+    security = user
+    
+    load printers = no
+    printcap name = /dev/null
+    printing = bsd
+    
+    unix charset = UTF-8
+    dos charset = CP932
+    
+    workgroup = WORKGROUP
+    
+    server string = %h server (Samba, Ubuntu)
+    dns proxy = no
+    interfaces = eth* lo
+    bind interfaces only = no
+    log file = /var/log/samba/log.%m
+    max log size = 1000
+    syslog = 0
+    panic action = /usr/share/samba/panic-action %d
+    server role = standalone server
+    passdb backend = tdbsam
+    obey pam restrictions = yes
+    unix password sync = yes
+    passwd program = /usr/bin/passwd %u
+    passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
+    pam password change = yes
+    map to guest = Bad User
+    usershare allow guests = yes
+
+[public]
+    path = /opt/samba/share
+    writable = yes
+    printable = no
+    public = yes
+    guest only = yes
+    create mode = 0777
+    directory mode = 0777
+
+[user]
+    path = /opt/samba/user
+    writable = yes
+    printable = no
+    public = no
+    create mode = 0777
+    directory mode = 0777

--- a/webdav-apache-php7.3/Dockerfile
+++ b/webdav-apache-php7.3/Dockerfile
@@ -1,0 +1,29 @@
+FROM nextcloudci/php7.3:php7.3-3
+
+RUN apt-get update
+RUN apt-get install -y apache2 apache2-utils
+RUN a2enmod dav dav_fs
+RUN a2dissite 000-default
+
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_PID_FILE /var/run/apache2.pid
+ENV APACHE_LOCK_DIR /var/lock/apache2
+ENV APACHE_RUN_DIR /var/run/apache2
+
+RUN mkdir -p /var/lock/apache2; chown www-data /var/lock/apache2
+RUN mkdir -p /var/webdav; chown www-data /var/webdav
+
+ADD webdav.conf /etc/apache2/sites-available/webdav.conf
+RUN a2ensite webdav
+
+RUN htpasswd -cb /etc/apache2/webdav.password test pass
+RUN chown root:www-data /etc/apache2/webdav.password
+RUN chmod 640 /etc/apache2/webdav.password
+
+RUN apt-get autoremove -y && \
+    apt-get autoclean && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+

--- a/webdav-apache-php7.3/webdav.conf
+++ b/webdav-apache-php7.3/webdav.conf
@@ -1,0 +1,15 @@
+Alias /webdav /var/webdav/
+<Location /webdav/>
+    DAV on
+    Options +Indexes
+    AuthType Basic
+    AuthName "webdav"
+    AuthUserFile /etc/apache2/webdav.password
+    Require valid-user
+</Location>
+
+<Directory /var/webdav/>
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>


### PR DESCRIPTION
Similar to #171 this is just to be prepared when 7.1 is dropped in Nextcloud server.

@rullzer Please setup the needed Docker repositories to be able to tag the images ;-)

Note that the Samba native image depends on the Samba non native image, so it can not be tagged until that image is created.
