### PR TITLE
Update gradle / minSDK parsing for Android builds

### DIFF
--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -37,7 +37,7 @@ RUN cd /gradle && \
     grep -A 999 "^dependencies" android.gradle | grep -v "dependencies" >> build.gradle && \
     sed -i '/.*com.google.*/s/^.*\/\///g' build.gradle && \
     sed -i '/.*touch-image-view.*/s/^/\/\//g' build.gradle && \
-    sed -i s'#minSdkVersion\ 14#minSdkVersion\ 18#' build.gradle && \
+    sed -i s'#minSdkVersion\ 16#minSdkVersion\ 18#' build.gradle && \
     sed -i s"/implementation 'com.github.tobiaskaminsky:android-job:v1.2.6.1'//" build.gradle && \
     sed -i s"/implementation 'com.afollestad:sectioned-recyclerview:0.5.0'//" build.gradle && \
     sed -i s"/.*NC_TEST.*//" build.gradle && \

--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -30,7 +30,7 @@ RUN cd /gradle && \
     wget https://raw.githubusercontent.com/nextcloud/android-library/master/build.gradle -O android-library.gradle && \
     sed '/^ [ ]*dependencies/Q' android.gradle >> build.gradle && \
     echo "    dependencies {" >> build.gradle && \
-    sed -n '/^ .*dependencies/,/\}/p' android-library.gradle | grep -v dep >> build.gradle && \
+    sed -n '/^ .*dependencies.*{/,/\}/p' android-library.gradle | grep -v dep >> build.gradle && \
     grep -A 999 "^ [ ]*dependencies" android.gradle  | sed '/^dependencies/Q' | grep -v "dependencies" >> build.gradle && \
     echo "dependencies {" >> build.gradle && \
     sed -n '/^dependencies/,/\}/p' android-library.gradle | grep -v dep | grep -v "}" >> build.gradle && \

--- a/android/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Thu Apr 18 07:07:10 CEST 2019
+#Wed Aug 21 07:03:37 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
-distributionSha256Sum=53b71812f18cdb2777e9f1b2a0f2038683907c90bdc406bc64d8b400e1fb2c3b
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/android/gradle/src/main/AndroidManifest.xml
+++ b/android/gradle/src/main/AndroidManifest.xml
@@ -9,6 +9,6 @@
 
     <uses-sdk
         android:minSdkVersion="18"
-        android:targetSdkVersion="25" />
+        android:targetSdkVersion="28" />
 
 </manifest>


### PR DESCRIPTION
Update gradle to 5.4.1
Update minSDK replacement to 16

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>