### PR TITLE
Desktop translations: Fix missing <numerusform> elements after lconvert

### DIFF
--- a/translations/handleDesktopTranslations.sh
+++ b/translations/handleDesktopTranslations.sh
@@ -38,7 +38,10 @@ do
 done
 
 # Merge source translation files and filter duplicates
-lconvert-qt5 -i /branches/*.ts -o translations/client_en.ts
+lconvert-qt5 -i /branches/*.ts -o /merged_en.ts
+
+# Fix missing <numerusform> elements (always two are required but lconvert strips out one)
+sed 's/<numerusform><\/numerusform>/<numerusform><\/numerusform><numerusform><\/numerusform>/' /merged_en.ts > translations/client_en.ts
 
 # push sources
 tx push -s


### PR DESCRIPTION
Always two are required but lconvert strips out one, resulting in the following error on push to Transifex:

`tx ERROR: Error received from server: English pluralized strings should contain 2 plurals.`

Successfully tested the fix on my local dev environment 😸 