### PR TITLE
Desktop translations: Fix paths, changed by lconvert

### DIFF
--- a/translations/handleDesktopTranslations.sh
+++ b/translations/handleDesktopTranslations.sh
@@ -41,7 +41,8 @@ done
 lconvert-qt5 -i /branches/*.ts -o /merged_en.ts
 
 # Fix missing <numerusform> elements (always two are required but lconvert strips out one)
-sed 's/<numerusform><\/numerusform>/<numerusform><\/numerusform><numerusform><\/numerusform>/' /merged_en.ts > translations/client_en.ts
+# Fix paths, changed by lconvert
+sed -e 's/<numerusform><\/numerusform>/<numerusform><\/numerusform><numerusform><\/numerusform>/' -e 's/app\/desktop\/src/src/' /merged_en.ts > translations/client_en.ts
 
 # push sources
 tx push -s


### PR DESCRIPTION
All source file paths get changed by `lconvert`, example:

`<location filename="../app/desktop/src/gui/cloudproviders/cloudproviderwrapper.cpp" line="184"/`

Add a second command for execution to `sed` to undo these path changes:
`../app/desktop/src/` -> `../src/`

This is a rather cosmetic fix but it feels quite better ;-)