### PR TITLE
Add xdebug extension

### DIFF
--- a/php7.2/Dockerfile
+++ b/php7.2/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip2 apt-transport-https
     php7.2-cli php7.2-curl php7.2-pgsql php7.2-ldap \
     php7.2-sqlite php7.2-mysql php7.2-zip php7.2-xml \
     php7.2-mbstring php7.2-dev make libmagickcore-6.q16-2-extra unzip \
-    php7.2-redis php7.2-imagick php7.2-dev \
+    php7.2-redis php7.2-imagick php7.2-dev php-xdebug \
     libsystemd-dev && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*

--- a/php7.3/Dockerfile
+++ b/php7.3/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip2 apt-transport-https
     php7.3-cli php7.3-curl php7.3-pgsql php7.3-ldap \
     php7.3-sqlite php7.3-mysql php7.3-zip php7.3-xml php7.3-redis \
     php7.3-mbstring php7.3-dev make libmagickcore-6.q16-2-extra unzip \
-    php7.3-dev \
+    php7.3-redis php7.3-imagick php7.3-dev php-xdebug \
     libsystemd-dev && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*

--- a/php7.4/Dockerfile
+++ b/php7.4/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https
     php7.4-cli php7.4-curl php7.4-pgsql php7.4-ldap \
     php7.4-sqlite php7.4-mysql php7.4-zip php7.4-xml \
     php7.4-mbstring php7.4-dev make libmagickcore-6.q16-2-extra unzip \
-    php7.4-dev \
+    php7.4-redis php7.4-imagick php7.4-dev php-xdebug \
     libsystemd-dev && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3902676/77700152-ecbf2380-6fb3-11ea-908a-c7c5e23a0030.png)

![image](https://user-images.githubusercontent.com/3902676/77700199-02344d80-6fb4-11ea-80b3-129dd699d33e.png)


No coverage without xdebug ;) The extension is still disabled by default and only enabled for some drone jobs.