### PR TITLE
Add auto_groups to community translations

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -97,7 +97,8 @@
         "nextcloud forms",
         "HomeITAdmin nextcloud_geoblocker",
         "SergeyMosin appointments",
-        "mrzapp nextcloud-cookbook"
+        "mrzapp nextcloud-cookbook",
+        "stjosh auto_groups"
       ]
     },
     {


### PR DESCRIPTION
Once this is integrated, I'll gladly contribute the german translations myself on Transifex. 😄 

One more question: For the write-access of @nextcloud-bot to my repo, I have simply invited this account as a collaborator. I hope that's the correct way to go?