### PR TITLE
Added epubreader app for translations

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -93,6 +93,7 @@
         "e-alfred ocdownloader",
         "e-alfred flowupload",
         "e-alfred nextcloud-scanner",
+        "e-alfred epubreader",
         "gino0631 nextcloud-metadata",
         "nextcloud forms",
         "HomeITAdmin nextcloud_geoblocker",


### PR DESCRIPTION
I added the epubreader app repository as an additional translation target. Link to the repository is here: https://github.com/e-alfred/epubreader