### PR TITLE
Desktop: Upgrade to precompiled Qt 5.12.9 with OpenSSL 1.1.1g

### DIFF
--- a/client/Dockerfile-5.12
+++ b/client/Dockerfile-5.12
@@ -2,6 +2,15 @@ FROM ubuntu:xenial
 
 MAINTAINER Roeland Jago Douma <roeland@famdouma.nl>
 
+# Run 'docker build' with '--build-arg BUILD_QT=1' to build Qt from source (default: not set)
+ARG BUILD_QT
+
+ENV VER_QT 5.12.9
+ENV VER_QT_DATE 2020-07-21
+ENV VER_OPENSSL 1.1.1g
+
+ENV QT_ROOT /opt/qt${VER_QT}
+
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \
     apt-get install -y wget libsqlite3-dev git curl perl python \
@@ -65,9 +74,9 @@ RUN cd /tmp && \
 
 # Install openssl
 RUN cd /tmp && \
-    wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz && \
-    tar -xvf openssl-1.1.1g.tar.gz && \
-    cd openssl-1.1.1g && \
+    wget https://www.openssl.org/source/openssl-${VER_OPENSSL}.tar.gz && \
+    tar -xvf openssl-${VER_OPENSSL}.tar.gz && \
+    cd openssl-${VER_OPENSSL} && \
     ./config && \
     make && \
     make install && \
@@ -96,33 +105,48 @@ RUN cd /tmp && \
     ln -s /opt/clazy/AppRun /usr/bin/clazy && \
     cd ..
 
-## Download Qt-5.12 sources
-#RUN apt install -y xz-utils && \
-#    wget https://download.qt.io/official_releases/qt/5.12/5.12.8/single/qt-everywhere-src-5.12.8.tar.xz && \
-#    tar -xvf qt-everywhere-src-5.12.8.tar.xz && \
-#    cd qt-everywhere-src-5.12.8
 
-## Build Qt-5.12
-#RUN cd qt-everywhere-src-5.12.8 && \
-#    OPENSSL_LIBS='-L/usr/local/lib -lssl -lcrypto' ./configure -nomake tests -nomake examples -opensource \
-#        -confirm-license -release -openssl-linked -prefix /opt/qt5.12.8 && \
-#    make && \
-#    make install && \
-#    cd .. && \
-#    rm -rf qt-everywhere*
+###########################################################################
 
+# Download Qt-5.12 sources
+RUN if [ "$BUILD_QT" = "1" ] ; then echo Build Qt from source. && \
+      apt install -y xz-utils && \
+      wget https://download.qt.io/official_releases/qt/5.12/${VER_QT}/single/qt-everywhere-src-${VER_QT}.tar.xz && \
+      tar -xvf qt-everywhere-src-${VER_QT}.tar.xz && \
+      cd qt-everywhere-src-${VER_QT} \
+    ; fi
+
+# Build Qt-5.12
+RUN if [ "$BUILD_QT" = "1" ] ; then \
+      cd qt-everywhere-src-${VER_QT} && \
+      OPENSSL_LIBS='-L/usr/local/lib -lssl -lcrypto' ./configure -nomake tests -nomake examples -opensource \
+          -confirm-license -release -openssl-linked -prefix ${QT_ROOT} && \
+      make && \
+      make install && \
+      cd .. && \
+      rm -rf qt-everywhere* && \
+      tar cfJ /qt-bin-${VER_QT}-openssl-${VER_OPENSSL}-linux-x86_64-$(date +"%Y-%m-%d").tar.xz ${QT_ROOT} \
+    ; fi
 
 #
 # The following precompiled Qt package has been built with the commands above, using this Dockerfile.
 #
 # Since it takes a very long time to compile, the build on Docker Hub fails due to a timeout.
 #
-# This is why we're going to use our own precompiled version here. You may modify the comments in this
-# Dockerfile to build your own version on a dedicated build machine.
+# This is why we're going to use our own precompiled version here.
+#
+# Run 'docker build' with '--build-arg BUILD_QT=1' to build Qt from source (default: not set)
+# on a dedicated build machine:
+#
+#   docker build -t client-5.12 . --build-arg BUILD_QT=1
 #
 
 # Download Qt-5.12 precompiled
-RUN apt install -y xz-utils && \
-    wget https://download.nextcloud.com/desktop/development/qt/qt-bin-5.12.8-openssl-1.1.1g-linux-x86_64-2020-05-24.tar.xz && \
-    tar -xvf qt-bin-5.12.8-openssl-1.1.1g-linux-x86_64-2020-05-24.tar.xz && \
-    rm qt-bin-5.12.8-openssl-1.1.1g-linux-x86_64-2020-05-24.tar.xz
+ENV QT_TARBALL qt-bin-${VER_QT}-openssl-${VER_OPENSSL}-linux-x86_64-${VER_QT_DATE}.tar.xz
+
+RUN if [ "$BUILD_QT" != "1" ] ; then echo Download precompiled Qt. && \
+      apt install -y xz-utils && \
+      wget https://download.nextcloud.com/desktop/development/qt/${QT_TARBALL} && \
+      tar -xvf ${QT_TARBALL} && \
+      rm ${QT_TARBALL} \
+    ; fi

--- a/client/Dockerfile-5.12
+++ b/client/Dockerfile-5.12
@@ -67,7 +67,7 @@ RUN cd /tmp && \
     tar -xvf zlib-1.2.11.tar.gz && \
     cd zlib-1.2.11 && \
     ./configure && \
-    make && \
+    make -j$(nproc) && \
     make install && \
     cd .. && \
     rm -rf zlib*
@@ -78,7 +78,7 @@ RUN cd /tmp && \
     tar -xvf openssl-${VER_OPENSSL}.tar.gz && \
     cd openssl-${VER_OPENSSL} && \
     ./config && \
-    make && \
+    make -j$(nproc) && \
     make install && \
     cd .. && \
     rm -rf openssl*
@@ -121,7 +121,7 @@ RUN if [ "$BUILD_QT" = "1" ] ; then \
       cd qt-everywhere-src-${VER_QT} && \
       OPENSSL_LIBS='-L/usr/local/lib -lssl -lcrypto' ./configure -nomake tests -nomake examples -opensource \
           -confirm-license -release -openssl-linked -prefix ${QT_ROOT} && \
-      make && \
+      make -j$(nproc) && \
       make install && \
       cd .. && \
       rm -rf qt-everywhere* && \

--- a/client/Dockerfile-5.12
+++ b/client/Dockerfile-5.12
@@ -13,7 +13,7 @@ ENV QT_ROOT /opt/qt${VER_QT}
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \
-    apt-get install -y wget libsqlite3-dev git curl perl python \
+    apt-get install -y wget libsqlite3-dev git curl jq perl python \
         software-properties-common build-essential mesa-common-dev \
         pkg-config ninja-build
 
@@ -150,3 +150,5 @@ RUN if [ "$BUILD_QT" != "1" ] ; then echo Download precompiled Qt. && \
       tar -xvf ${QT_TARBALL} && \
       rm ${QT_TARBALL} \
     ; fi
+
+###########################################################################


### PR DESCRIPTION
### Upgrade to precompiled Qt 5.12.9

- Also implement `env` vars for specifying the _Qt_ and _OpenSSL_ versions, to get rid of some duplication as they are used very often.

- Add command line argument to enable building Qt from source with having to modify the `Dockerfile`:

  Run `docker build` with `--build-arg BUILD_QT=1` to build Qt from source (default: not set) on a dedicated build machine:
 
    `docker build -t client-5.12 . --build-arg BUILD_QT=1`

  Then for example run the following command to get the Qt tarball:

    ```
    docker run \
      --name build-qt-tmp \
      --rm \
      -v $(pwd):/output \
      client-5.12 \
      /bin/bash -c 'cp /qt-bin* /output/'
    ```
  
  Puts the tarball into the current working directory.

Other tweaks:

- Use `make -j$(nproc)` to use all available CPU cores
- Install `jq` package for the new CI bot (See: nextcloud/desktop#2213)
