### PR TITLE
Check if resources.qrc exists before passing it to lupdate

### DIFF
--- a/translations/handleDesktopTranslations.sh
+++ b/translations/handleDesktopTranslations.sh
@@ -34,7 +34,13 @@ do
 
   git checkout $version
 
-  lupdate src/gui/ src/cmd/ src/common/ src/crashreporter/ src/csync/ src/libsync/ resources.qrc -ts /branches/$version.ts
+  if [[ -f './resources.qrc' ]]; then
+    resources="resources.qrc"
+  else
+    resources=""
+  fi
+
+  lupdate src/gui/ src/cmd/ src/common/ src/crashreporter/ src/csync/ src/libsync/ $resources -ts /branches/$version.ts
 done
 
 # Merge source translation files and filter duplicates


### PR DESCRIPTION
Indeed some of the stable branches in the desktop repository don't
contain that file.

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>