### PR TITLE
translationtool: ignore node_modules when searching apps

### DIFF
--- a/translations/translationtool/src/translationtool.php
+++ b/translations/translationtool/src/translationtool.php
@@ -477,6 +477,10 @@ class TranslationTool {
 				continue;
 			}
 
+			if ($entry === 'node_modules') {
+				continue;
+			}
+
 			if ($entry === 'l10n') {
 				$this->appPaths[] = $path;
 			} else {


### PR DESCRIPTION
Some node modules such as `moment` contain a `l10n` subdirectory.
There's even a `l10n` node module inside `@nextcloud`.

When run inside an app directory with a node_modules folder
translation tool tries to extract strings from these.

Alternative approaches would be:
* respect the content of `.l10nignore` when searching apps
* don't search subdirectories if we already found an `l10n` dir in this one

Picked the simplest one for a start.

Signed-off-by: Azul <azul@riseup.net>