### PR TITLE
Add cmocka to the CI image

### DIFF
--- a/client/Dockerfile-5.12
+++ b/client/Dockerfile-5.12
@@ -37,6 +37,8 @@ RUN sed -i '/deb-src/s/^# //' /etc/apt/sources.list && \
         cmake \
         zlib1g-dev \
         xz-utils \
+# For cmocka based csync tests
+        libcmocka-dev \
 # Add libsecret for qtkeychain
         libsecret-1-dev \
 # Add Qt-5.12 build dependencies


### PR DESCRIPTION
This is necessary to make sure the csync tests are executed

Signed-off-by: Kevin Ottens <kevin.ottens@nextcloud.com>