### PR TITLE
Bump 7.3 container to debian buster and enable apcu

### DIFF
--- a/php7.3/Dockerfile
+++ b/php7.3/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:jessie
-RUN apt-get update && apt-get install -y wget gnupg2 libzip2 apt-transport-https lsb-release ca-certificates && \
+FROM debian:buster
+RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https lsb-release ca-certificates && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && apt-get install -y php7.3-intl php7.3-gd git curl \
-    php7.3-cli php7.3-curl php7.3-pgsql php7.3-ldap \
+    php7.3-cli php7.3-curl php7.3-pgsql php7.3-ldap php7.3-apcu \
     php7.3-sqlite php7.3-mysql php7.3-zip php7.3-xml php7.3-redis \
     php7.3-mbstring php7.3-dev make libmagickcore-6.q16-2-extra unzip \
     php7.3-redis php7.3-imagick php7.3-dev php-xdebug \

--- a/php7.3/nextcloud.ini
+++ b/php7.3/nextcloud.ini
@@ -8,3 +8,6 @@ opcache.max_accelerated_files=10000
 opcache.memory_consumption=128
 opcache.save_comments=1
 opcache.revalidate_freq=1
+
+apcu.enabled=1
+apcu.enable_cli=1


### PR DESCRIPTION
Step 1 to enable memory caching during integration tests

Once we have a new base image we can bump the integration-php7.3 one which is based on this one and enable memory caching on integration tests which has shown quite some performance boost on my local setup especially in the federation tests which otherwise were sometimes fragile with timeouts.

