### PR TITLE
Add php7.4 container for integration tests

### DIFF
--- a/integration-php7.4/Dockerfile
+++ b/integration-php7.4/Dockerfile
@@ -1,0 +1,9 @@
+FROM nextcloudci/php7.4:php7.4-2
+
+RUN composer global require hirak/prestissimo
+
+RUN mkdir /tmp/server && \
+    cd /tmp/server && git clone --recursive https://github.com/nextcloud/server.git && \
+    cd /tmp/server/server/build/integration && composer install && \
+    cd /tmp/server/server/tests/acceptance && composer install && \
+    rm -rf /tmp/server

--- a/php7.4/Dockerfile
+++ b/php7.4/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https
     php7.4-cli php7.4-curl php7.4-pgsql php7.4-ldap \
     php7.4-sqlite php7.4-mysql php7.4-zip php7.4-xml \
     php7.4-mbstring php7.4-dev make libmagickcore-6.q16-2-extra unzip \
-    php7.4-redis php7.4-imagick php7.4-dev php-xdebug \
+    php7.4-redis php7.4-imagick php7.4-dev php7.4-xdebug php7.4-apcu \
     libsystemd-dev && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*


### PR DESCRIPTION
Required for https://github.com/nextcloud/server/pull/24587 in order to properly test federated shares going to the same instance, as with that we can actually use PHP_CLI_SERVER_WORKERS to make sure that requests against the same instance don't run into a timeout because the php interla server only has one worker with php 7.3.