### PR TITLE
Sign-off the translations generated by the translation bot

### DIFF
--- a/translations/handleAppTranslations.sh
+++ b/translations/handleAppTranslations.sh
@@ -91,7 +91,7 @@ do
 
   # create git commit and push it
   git add l10n/*.js l10n/*.json
-  git commit -am "[tx-robot] updated from transifex" s || true
+  git commit -am "[tx-robot] updated from transifex" -s || true
   git push origin $version
 
   echo "done with $version"

--- a/translations/handleAppTranslations.sh
+++ b/translations/handleAppTranslations.sh
@@ -91,7 +91,7 @@ do
 
   # create git commit and push it
   git add l10n/*.js l10n/*.json
-  git commit -am "[tx-robot] updated from transifex" || true
+  git commit -am "[tx-robot] updated from transifex" s || true
   git push origin $version
 
   echo "done with $version"

--- a/translations/handleAppsTranslations.sh
+++ b/translations/handleAppsTranslations.sh
@@ -51,6 +51,6 @@ do
 done
 
 # create git commit and push it
-git commit -m "[tx-robot] updated from transifex" || true
+git commit -m "[tx-robot] updated from transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleAppstoreTranslations.sh
+++ b/translations/handleAppstoreTranslations.sh
@@ -28,6 +28,6 @@ rm -rf locale/de_DE/
 
 # create git commit and push it
 git add locale/
-git commit -am "[tx-robot] updated from transifex" || true
+git commit -am "[tx-robot] updated from transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleChangelogServerTranslations.sh
+++ b/translations/handleChangelogServerTranslations.sh
@@ -25,6 +25,6 @@ php /translationtool/generate-xml.php /app/data/
 
 # create git commit and push it
 git add .
-git commit -am "[tx-robot] updated from transifex" || true
+git commit -am "[tx-robot] updated from transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleDesktopTranslations.sh
+++ b/translations/handleDesktopTranslations.sh
@@ -74,7 +74,7 @@ do
 
   # create git commit and push it
   git add .
-  git commit -am "[tx-robot] updated from transifex" || true
+  git commit -am "[tx-robot] updated from transifex" -s || true
   git push origin $version
   echo "done with $version"
 done

--- a/translations/handleExternalBranchedAndroidTranslations.sh
+++ b/translations/handleExternalBranchedAndroidTranslations.sh
@@ -28,6 +28,6 @@ fi
 
 # create git commit and push it
 git add .
-git commit -am "[tx-robot] updated from transifex" || true
+git commit -am "[tx-robot] updated from transifex" -s || true
 git push -f origin $3
 echo "done"

--- a/translations/handlePlainTranslations.sh
+++ b/translations/handlePlainTranslations.sh
@@ -104,7 +104,7 @@ do
 
   # create git commit and push it
   git add .
-  git commit -am "[tx-robot] updated from transifex" || true
+  git commit -am "[tx-robot] updated from transifex" -s || true
   git push origin $version
   echo "done"
 done

--- a/translations/handleTranslations.sh
+++ b/translations/handleTranslations.sh
@@ -71,7 +71,7 @@ do
   # create git commit and push it
   git add apps core lib
 
-  git commit -am "[tx-robot] updated from transifex" || true
+  git commit -am "[tx-robot] updated from transifex" -s || true
   git push origin $version
 
   echo "done with $version"

--- a/translations/handleWindowsPhoneAppTranslations.sh
+++ b/translations/handleWindowsPhoneAppTranslations.sh
@@ -20,6 +20,6 @@ tx pull -f -a --minimum-perc=75
 
 # create git commit and push it
 git add .
-git commit -am "[tx-robot] updated from transifex" || true
+git commit -am "[tx-robot] updated from transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleiOSTalkTranslations.sh
+++ b/translations/handleiOSTalkTranslations.sh
@@ -32,6 +32,6 @@ cd ..
 
 # create git commit and push it
 git add .
-git commit -am "[tx-robot] updated from transifex" || true
+git commit -am "[tx-robot] updated from transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleiOSTranslations.sh
+++ b/translations/handleiOSTranslations.sh
@@ -33,6 +33,6 @@ cd ..
 
 # create git commit and push it
 git add .
-git commit -am "[tx-robot] updated from transifex" || true
+git commit -am "[tx-robot] updated from transifex" -s || true
 git push origin develop
 echo "done"


### PR DESCRIPTION
All commits in all PRs of apps are piped through the DCO checker. Depending on the CI/CD routines of the app, this causes problems with the commits from the translation bot. So, you get a ton of errors when merging changes between different branches. If the need for further explanations is there, I can open an issue to explain the problem in detail.

This PR should make the bot signoff all translation commits from transifex. This is not reduced to the apps but to all here existing integrations. If not desired for an individual integration I can remove it. But I think, it should be consistent.