### PR TITLE
refresh SAML 7.3 image

### DIFF
--- a/user_saml_shibboleth-php7.3/Dockerfile
+++ b/user_saml_shibboleth-php7.3/Dockerfile
@@ -4,7 +4,7 @@ FROM unicon/shibboleth-idp:3.4.3
 ADD shibboleth/ /opt/shibboleth-idp/
 
 # Install the LDAP server
-RUN yum install -y  https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-12.noarch.rpm
+RUN yum install -y  https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-13.noarch.rpm
 RUN yum install -y --enablerepo=centosplus 389-ds
 RUN rm -fr /var/lock /usr/lib/systemd/system
 ADD ldap/ds-setup.inf /ds-setup.inf

--- a/user_saml_shibboleth-php7.3/Dockerfile
+++ b/user_saml_shibboleth-php7.3/Dockerfile
@@ -32,3 +32,5 @@ RUN yum -y install nc
 # Add the startup file
 ADD start.sh /start.sh
 RUN chmod a+x /start.sh
+
+CMD ["/start.sh"]

--- a/user_saml_shibboleth-php7.3/start.sh
+++ b/user_saml_shibboleth-php7.3/start.sh
@@ -29,4 +29,4 @@ do
    sleep 1
 done
 
-run-jetty.sh &
+run-jetty.sh


### PR DESCRIPTION
The integration tests at user_saml fail, typically with broken LDAP connections. I could not reproduce the same issue with the image locallcy, but different ones. Partially it is also because jetty was started twice, but the default launch script,  and with ours. At least the startup appears OK for me.