### PR TITLE
Disable unused TranslatableApp::createFakeFileForAppInfo() translations

### DIFF
--- a/translations/translationtool/src/translationtool.php
+++ b/translations/translationtool/src/translationtool.php
@@ -240,10 +240,6 @@ class TranslatableApp {
 		
 		$strings = [];
 		$xml = simplexml_load_file($entryName);
-		
-		if ($xml->name) {
-			$strings[] = $xml->name->__toString();
-		}
 
 		if ($xml->navigations) {
 			foreach ($xml->navigations as $navigation) {
@@ -254,6 +250,8 @@ class TranslatableApp {
 			}
 		}
 
+		// FIXME: currently unused info.xml translations
+		/*
 		if ($xml->name) {
 			if ($xml->name->count() > 1) {
 				foreach ($xml->name as $name) {
@@ -307,6 +305,7 @@ class TranslatableApp {
 				}
 			}
 		}
+		*/
 		
 		$content = '<?php' . PHP_EOL;
 		foreach ($strings as $string) {


### PR DESCRIPTION
See https://github.com/nextcloud/cms_pico/issues/152, specifically https://github.com/nextcloud/cms_pico/issues/152#issuecomment-801918363 explaining that these strings aren't currently used and it isn't planned to use them in the near future

I specifically chose to just comment the relevant code parts because adding translatable app descriptions might be a good idea for the future. Lines 243-246 are duplicate code (see lines 268-271). If the same strings exist somewhere else in the app, they are still parsed as usual.