### PR TITLE
Make php7.1 image build

### DIFF
--- a/php7.1/Dockerfile
+++ b/php7.1/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:jessie
-RUN apt-get update && apt-get install -y wget gnupg2 libzip2 apt-transport-https lsb-release ca-certificates && \
+FROM debian:buster
+RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https lsb-release ca-certificates && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && apt-get install -y php7.1-intl php7.1-gd git curl \
@@ -7,7 +7,9 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip2 apt-transport-https
     php7.1-apcu php7.1-redis php7.1-sqlite php7.1-mysql php7.1-zip php7.1-xml \
     php7.1-mbstring php7.1-xdebug php7.1-dev make libmagickcore-6.q16-2-extra unzip && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* && \
+    # Make sure that the php version being used is php7.1
+    rm /usr/bin/php && ln -s /usr/bin/php7.1 /usr/bin/php
 
 RUN cd /tmp/ && wget https://github.com/nikic/php-ast/archive/master.zip && unzip master.zip
 RUN cd /tmp/php-ast-master/ && phpize && ./configure && make && make install && rm -rf /tmp/php-ast-master/


### PR DESCRIPTION
The php7.1 image fails to build at the moment. This fixes that.