### PR TITLE
Install M2Crypto into the Debian image

### DIFF
--- a/client-debian/Dockerfile
+++ b/client-debian/Dockerfile
@@ -1,4 +1,5 @@
+
 FROM ubuntu:focal
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y devscripts cdbs osc git
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y devscripts cdbs osc git python3-m2crypto


### PR DESCRIPTION
It seems that OSC needs the python3-m2crypto package, but does not depend on it.