### PR TITLE
Move supported php versions to GitHub Container Registry

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,54 @@
+name: Docker Image Build
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '*/Dockerfile'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '*/Dockerfile'
+
+jobs:
+  files:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.dockerfile.outputs.matrix }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get changed files
+      id: files
+      uses: jitterbit/get-changed-files@v1
+      with:
+        format: json
+
+    - name: Extract Dockerfile files
+      id: dockerfile
+      run: |
+        FILES=$( echo '${{ steps.files.outputs.added_modified }}' | jq -c 'map(select(. | endswith("Dockerfile")))' )
+        echo "::set-output name=matrix::$FILES"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: files
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: ${{ fromJSON(needs.files.outputs.matrix) }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Build Docker image ${{ matrix.dockerfile }}
+      run: |
+        cd "$(dirname ${{ matrix.dockerfile }})"
+        docker build . --file Dockerfile

--- a/integration-php7.3/Dockerfile
+++ b/integration-php7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloudci/php7.3:php7.3-5
+FROM ghcr.io/nextcloud/continuous-integration-php7.3:latest
 
 RUN composer global require hirak/prestissimo
 

--- a/integration-php7.4/Dockerfile
+++ b/integration-php7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloudci/php7.4:php7.4-3
+FROM ghcr.io/nextcloud/continuous-integration-php7.4:latest
 
 RUN composer global require hirak/prestissimo
 

--- a/integration-php8.0/Dockerfile
+++ b/integration-php8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloudci/php8.0:php8.0-2
+FROM ghcr.io/nextcloud/continuous-integration-php8.0:latest
 
 RUN composer global require hirak/prestissimo
 

--- a/php7.3-memcached/Dockerfile
+++ b/php7.3-memcached/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloudci/php7.3:php7.3-3
+FROM ghcr.io/nextcloud/continuous-integration-php7.3:latest
 RUN apt-get update && \
     apt-get purge -y php7.3-apcu && \
     apt-get install -y php7.3-memcached memcached && \

--- a/samba-non-native-php7.3/Dockerfile
+++ b/samba-non-native-php7.3/Dockerfile
@@ -1,5 +1,5 @@
 # Based upon https://hub.docker.com/r/silvershell/samba/
-FROM nextcloudci/php7.3:php7.3-3
+FROM ghcr.io/nextcloud/continuous-integration-php7.3:latest
 
 ENV SMB_USER smbuser
 ENV SMB_PASSWORD smbpassword

--- a/webdav-apache-php7.3/Dockerfile
+++ b/webdav-apache-php7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloudci/php7.3:php7.3-3
+FROM ghcr.io/nextcloud/continuous-integration-php7.3:latest
 
 RUN apt-get update
 RUN apt-get install -y apache2 apache2-utils


### PR DESCRIPTION
Otherwise anything that rely on the base php images will be outdated from the docker registry