### PR TITLE
fetching desktop client translations are failing: ignore errors

### DIFF
--- a/translations-desktop/handleDesktopTranslations.sh
+++ b/translations-desktop/handleDesktopTranslations.sh
@@ -70,7 +70,8 @@ do
   git checkout $version
 
   # pull translations
-  tx pull -f -a --minimum-perc=25
+  tx pull -f -a --minimum-perc=25 -r nextcloud.client
+  bash -c 'tx pull -f -a --minimum-perc=25 -r nextcloud.client-desktop ; echo ""'
 
   # create git commit and push it
   git add .


### PR DESCRIPTION
fetching translations for desktop (i.e. .desktop freedesktop file) is
erroring in the transifex server
we will make sure that is not blocing pull of all translations

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>