### PR TITLE
Add MariaDB 10.6

### DIFF
--- a/mariadb-10.6/Dockerfile
+++ b/mariadb-10.6/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb:10.6


### PR DESCRIPTION
As this version as some BC breaks, tests need to be done against it.
See https://github.com/nextcloud/server/issues/25436