### PR TITLE
server: update, install and cleanup in one step

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,23 +1,20 @@
 FROM debian:stable
 
-# Update repos
+# Update repos install packages and cleanup
+# all in one step so we avoid large intermediate layers.
 RUN apt-get update && \ 
     apt-get install -y wget gnupg2 git libzip4 apt-transport-https lsb-release ca-certificates && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
-    apt-get update
-
-# Install packages
-RUN apt-get install -y php7.3-cli php7.3-common php7.3-mbstring \
+    apt-get update && \
+    apt-get install -y php7.3-cli php7.3-common php7.3-mbstring \
     php7.3-gd php-imagick php7.3-intl php7.3-bz2 php7.3-xml \
     php7.3-mysql php7.3-zip php7.3-dev curl php7.3-curl \
     php-dompdf php-apcu redis-server php-redis php-smbclient \
     php7.3-ldap unzip php7.3-pgsql php7.3-sqlite make apache2 \
     php7.3-json php7.3-opcache libmagickcore-6.q16-2-extra \
-    libapache2-mod-php7.3
-
-# Cleanup
-RUN apt-get autoremove -y && apt-get autoclean && apt-get clean && \
+    libapache2-mod-php7.3 && \
+    apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 COPY opcache-recommended.ini /usr/local/etc/php/conf.d/


### PR DESCRIPTION
Each RUN command creates a new layer.
If we split the installation and the cleanup
we end up with a large intermediate layer
that does not add any value but increases the download size.