### PR TITLE
Server: pin some other extension to php 7.4

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && \
     apt-get install -y php7.4-cli php7.4-common php7.4-mbstring \
-    php7.4-gd php-imagick php7.4-intl php7.4-bz2 php7.4-xml \
+    php7.4-gd php7.4-imagick php7.4-intl php7.4-bz2 php7.4-xml \
     php7.4-mysql php7.4-zip php7.4-dev curl php7.4-curl \
-    php-dompdf php-apcu redis-server php-redis php-smbclient \
+    php-dompdf php7.4-apcu redis-server php7.4-redis php7.4-smbclient \
     php7.4-ldap unzip php7.4-pgsql php7.4-sqlite make apache2 \
     php7.4-json php7.4-opcache libmagickcore-6.q16-2-extra \
     libapache2-mod-php7.4 && \

--- a/shallow-server/Dockerfile
+++ b/shallow-server/Dockerfile
@@ -7,13 +7,13 @@ RUN apt-get update && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && \
-    apt-get install -y php7.3-cli php7.3-common php7.3-mbstring \
-    php7.3-gd php-imagick php7.3-intl php7.3-bz2 php7.3-xml \
-    php7.3-mysql php7.3-zip php7.3-dev curl php7.3-curl \
-    php-dompdf php-apcu redis-server php-redis php-smbclient \
-    php7.3-ldap unzip php7.3-pgsql php7.3-sqlite make apache2 \
-    php7.3-json php7.3-opcache libmagickcore-6.q16-2-extra \
-    libapache2-mod-php7.3 && \
+    apt-get install -y php7.4-cli php7.4-common php7.4-mbstring \
+    php7.4-gd php7.4-imagick php7.4-intl php7.4-bz2 php7.4-xml \
+    php7.4-mysql php7.4-zip php7.4-dev curl php7.4-curl \
+    php-dompdf php7.4-apcu redis-server php7.4-redis php7.4-smbclient \
+    php7.4-ldap unzip php7.4-pgsql php7.4-sqlite make apache2 \
+    php7.4-json php7.4-opcache libmagickcore-6.q16-2-extra \
+    libapache2-mod-php7.4 && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
https://github.com/nextcloud/docker-ci/pull/349
https://github.com/nextcloud/viewer/pull/1154

- [ ] Release [nextcloud/docker-ci/pkgs/container/continuous-integration-server](https://github.com/nextcloud/docker-ci/pkgs/container/continuous-integration-server) when merged
- [ ] Release [nextcloud/docker-ci/pkgs/container/continuous-integration-shallow-server](https://github.com/nextcloud/docker-ci/pkgs/container/continuous-integration-shallow-server) when merged