### PR TITLE
Add a worflow to check if translationtool.phar is build

### DIFF
--- a/.github/workflows/translationtool-build.yml
+++ b/.github/workflows/translationtool-build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: translationtool.phar
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up php 8.0
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.0"
+          coverage: none
+
+      - name: Build translationtool.phar
+        working-directory: translations/translationtool/
+        run: make translationtool.phar
+
+      - name: Check build changes
+        run: |
+          git status --porcelain translations/translationtool/
+          bash -c "[[ ! \"`git status --porcelain translations/translationtool/translationtool.phar`\" ]] || exit 1"


### PR DESCRIPTION
An attempt to prevent issues with forgotten/missing recompile like #355 fixed in #362 

Unluckily it seems to be dirty when I compile locally.
I tried to diff the phar and there are some additional non-source files in one of the vendor dependencies (LICENSE, README.md, ...) but I cleared the vendor directories locally so actions and me use the same: composer.lock state, a clean vendor/ folder, same php version, ....

I have no clue. So I will just save this as a draft for now.