### PR TITLE
Remove deprecated prestissimo composer plugin

### DIFF
--- a/integration-php7.3/Dockerfile
+++ b/integration-php7.3/Dockerfile
@@ -1,7 +1,5 @@
 FROM ghcr.io/nextcloud/continuous-integration-php7.3:latest
 
-RUN composer global require hirak/prestissimo
-
 RUN mkdir /tmp/server && \
     cd /tmp/server && git clone --recursive https://github.com/nextcloud/server.git && \
     cd /tmp/server/server/build/integration && composer install && \

--- a/integration-php7.3/Dockerfile
+++ b/integration-php7.3/Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/nextcloud/continuous-integration-php7.3:latest
 
+RUN composer global require hirak/prestissimo
+
 RUN mkdir /tmp/server && \
     cd /tmp/server && git clone --recursive https://github.com/nextcloud/server.git && \
     cd /tmp/server/server/build/integration && composer install && \

--- a/integration-php7.4/Dockerfile
+++ b/integration-php7.4/Dockerfile
@@ -1,7 +1,5 @@
 FROM ghcr.io/nextcloud/continuous-integration-php7.4:latest
 
-RUN composer global require hirak/prestissimo
-
 RUN mkdir /tmp/server && \
     cd /tmp/server && git clone --recursive https://github.com/nextcloud/server.git && \
     cd /tmp/server/server/build/integration && composer install && \

--- a/integration-php8.0/Dockerfile
+++ b/integration-php8.0/Dockerfile
@@ -1,7 +1,5 @@
 FROM ghcr.io/nextcloud/continuous-integration-php8.0:latest
 
-RUN composer global require hirak/prestissimo
-
 RUN mkdir /tmp/server && \
     cd /tmp/server && git clone --recursive https://github.com/nextcloud/server.git && \
     cd /tmp/server/server/build/integration && composer install && \


### PR DESCRIPTION
hirak/prestissimo README says:
This plugin is for Composer1;
Composer2 is very fast on its own.
Uninstall this plugin and update the Composer itself.

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>