### PR TITLE
Add Transfer app for translation

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -103,6 +103,7 @@
         "ayselafsar dicomviewer",
         "baimard gestion",
         "CollaboraOnline richdocumentscode",
+        "danth transfer",
         "datenangebot health",
         "datenangebot tables",
         "e-alfred epubreader",


### PR DESCRIPTION
Added [Transfer](https://github.com/danth/transfer) to the translation workflow.

@nextcloud-bot has already been invited to the repository.

Closes danth/transfer#9.