### PR TITLE
shallow-server: Fix branch checkout for branches other than master

### DIFF
--- a/shallow-server/initnc.sh
+++ b/shallow-server/initnc.sh
@@ -7,8 +7,8 @@ cd /var/www/html/
 
 # Update code
 su www-data -c "
-git fetch origin ${BRANCH} --depth 1
-git checkout origin/$BRANCH -B $BRANCH
+git fetch origin $BRANCH:$BRANCH --depth 1
+git checkout $BRANCH
 git submodule update
 
 # Creating data


### PR DESCRIPTION
When trying to run `initnc.sh` with any branch other than `master` in the `shallow-server` image, this error came up:

```
#5 15.57 fatal: 'origin/stable23' is not a commit and a branch 'stable23' cannot be created from it
```

However, the script didn't fail as it doesn't have fail-on-error flags. This results in the server just initializing with `master` regardless of the `BRANCH` variable.

This PR fixes that by properly fetching the branch to a local branch, and then checking out that.
