### PR TITLE
Add diary to app list for translation

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -130,7 +130,8 @@
         "stjosh auto_groups",
         "sualko cloud_bbb",
         "tacruc gpgmailer",
-        "westberliner checksum"
+        "westberliner checksum",
+		"danielroehrig diary"
       ]
     },
     {

--- a/translations/config.json
+++ b/translations/config.json
@@ -103,6 +103,7 @@
         "ayselafsar dicomviewer",
         "baimard gestion",
         "CollaboraOnline richdocumentscode",
+        "danielroehrig diary",
         "datenangebot health",
         "datenangebot tables",
         "e-alfred epubreader",
@@ -130,8 +131,7 @@
         "stjosh auto_groups",
         "sualko cloud_bbb",
         "tacruc gpgmailer",
-        "westberliner checksum",
-		"danielroehrig diary"
+        "westberliner checksum"
       ]
     },
     {


### PR DESCRIPTION
I would love for the diary app to be translated by the transifex nextcloud group. Hopefully, I did all the right changes in my app, but if I didn't, please contact me. ATM it's just one string that should be translated as a test. If it works, I will add all the others too. I invited nextcloud-bot to be a collaborator so that I can give it write access, but it didn't accept. I am following [this guide](https://docs.nextcloud.com/server/latest/developer_manual/basics/front-end/l10n.html?highlight=translation) here.