### PR TITLE
shallow-server: Fix branch checkout (again)

### DIFF
--- a/shallow-server/initnc.sh
+++ b/shallow-server/initnc.sh
@@ -7,8 +7,8 @@ cd /var/www/html/
 
 # Update code
 su www-data -c "
-git fetch origin $BRANCH:$BRANCH --depth 1
-git checkout $BRANCH
+git fetch --force --depth 1 origin $BRANCH:refs/remotes/origin/$BRANCH
+git checkout origin/$BRANCH -B $BRANCH
 git submodule update
 
 # Creating data


### PR DESCRIPTION
Unfortunately, #371 fixed the checkout for branches other than master, but broke master. This wasn't visible at first glance because when testing, the image was up to date.

Master broke because trying to fetch to an already existing branch, and once again the script doesn't fail on errors.

I have now validated both branches with old and new starting points, and it should work for any.


