### PR TITLE
Continune when the grep fails

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -16,8 +16,11 @@ if [ ! -f '/app/.tx/config' ]; then
   exit 1
 fi
 
+# We actually want this command to fail
+set +e
 grep 'MYAPP' '/app/.tx/config'
 INVALID_CONFIG=$?
+set -e
 if [ "$INVALID_CONFIG" = "0" ]; then
   echo "Invalid transifex configuration file .tx/config (translating MYAPP instead of real value)"
   exit 2


### PR DESCRIPTION
I missed the `set -xe` at the top, but we need to allow errors as we want the grep to "fail"