### PR TITLE
Fix transifex sync with resource vs appid mismatch

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -16,12 +16,8 @@ if [ ! -f '/app/.tx/config' ]; then
   exit 1
 fi
 
-# We actually want this command to fail
-set +e
-grep 'MYAPP' '/app/.tx/config'
-INVALID_CONFIG=$?
-set -e
-if [ "$INVALID_CONFIG" = "0" ]; then
+RESOURCE_ID=$(grep -oE '\[nextcloud\..*\]' .tx/config | sed -E 's/\[nextcloud.(.*)\]/\1/')
+if [ "$RESOURCE_ID" = "MYAPP" ]; then
   echo "Invalid transifex configuration file .tx/config (translating MYAPP instead of real value)"
   exit 2
 fi
@@ -66,7 +62,7 @@ do
   cd translationfiles/templates/
   for file in $(ls)
   do
-    mv $file ../../stable-templates/$version.$file
+    mv $file ../../stable-templates/$version.$RESOURCE_ID.pot
   done
   cd ../..
 done

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -16,6 +16,7 @@ if [ ! -f '/app/.tx/config' ]; then
   exit 1
 fi
 
+APP_ID=$(grep -oE '<id>.*</id>' appinfo/info.xml | sed -E 's/<id>(.*)<\/id>/\1/')
 RESOURCE_ID=$(grep -oE '\[nextcloud\..*\]' .tx/config | sed -E 's/\[nextcloud.(.*)\]/\1/')
 if [ "$RESOURCE_ID" = "MYAPP" ]; then
   echo "Invalid transifex configuration file .tx/config (translating MYAPP instead of real value)"
@@ -88,6 +89,22 @@ tx push -s
 
 # pull translations - force pull because a fresh clone has newer time stamps
 tx pull -f -a --minimum-perc=5
+
+# Copy back the po files from transifex resource id to app id
+if [ "$RESOURCE_ID" = "$APP_ID" ] ; then
+  echo 'App id and transifex resource id are the same, not renaming po files …'
+else
+  echo "App id [$APP_ID] and transifex resource id [$RESOURCE_ID] mismatch"
+  echo 'Renaming po files …'
+  for file in $(ls translationfiles)
+  do
+    if [ "$file" = 'templates' ]; then
+      continue;
+    fi
+
+    mv translationfiles/$file/$RESOURCE_ID.po translationfiles/$file/$APP_ID.po
+  done
+fi
 
 # reverse version list to apply backports
 backportVersions=$(echo $versions | awk '{for(i=NF;i>=1;i--) printf "%s ", $i;print ""}')


### PR DESCRIPTION
### Step 1

> tx ERROR: [Errno 2] No such file or directory: '/app/translationfiles/templates/files_libreofficeedit.pot'
- [x] Build triggered: https://github.com/nextcloud/docker-ci/actions/runs/2970939890
- [x] Run for the app id of #400 

### Step 2

I guess we also need to rename the po files before we can run the `translationtool.phar convert-po-files`

But the next run will show

Fix #400