### PR TITLE
Only use the first <id> line

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -16,7 +16,7 @@ if [ ! -f '/app/.tx/config' ]; then
   exit 1
 fi
 
-APP_ID=$(grep -oE '<id>.*</id>' appinfo/info.xml | sed -E 's/<id>(.*)<\/id>/\1/')
+APP_ID=$(grep -oE '<id>.*</id>' appinfo/info.xml | head --lines 1 | sed -E 's/<id>(.*)<\/id>/\1/')
 RESOURCE_ID=$(grep -oE '\[nextcloud\..*\]' .tx/config | sed -E 's/\[nextcloud.(.*)\]/\1/')
 if [ "$RESOURCE_ID" = "MYAPP" ]; then
   echo "Invalid transifex configuration file .tx/config (translating MYAPP instead of real value)"

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -18,6 +18,8 @@ fi
 
 APP_ID=$(grep -oE '<id>.*</id>' appinfo/info.xml | head --lines 1 | sed -E 's/<id>(.*)<\/id>/\1/')
 RESOURCE_ID=$(grep -oE '\[nextcloud\..*\]' .tx/config | sed -E 's/\[nextcloud.(.*)\]/\1/')
+SOURCE_FILE=$( grep -oE '^source_file\s*=\s*(.+)$' | sed -E 's/source_file\s*=\s*(.+)/\1/')
+
 if [ "$RESOURCE_ID" = "MYAPP" ]; then
   echo "Invalid transifex configuration file .tx/config (translating MYAPP instead of real value)"
   exit 2
@@ -72,13 +74,13 @@ done
 for file in $(ls stable-templates/master.*)
 do
   name=$(echo $file | cut -b 25- )
-  msgcat --use-first stable-templates/*.$name > translationfiles/templates/$name
+  msgcat --use-first stable-templates/*.$name > $SOURCE_FILE
 done
 # alternative merge of main branch
 for file in $(ls stable-templates/main.*)
 do
   name=$(echo $file | cut -b 23- )
-  msgcat --use-first stable-templates/*.$name > translationfiles/templates/$name
+  msgcat --use-first stable-templates/*.$name > $SOURCE_FILE
 done
 
 # remove intermediate POT files


### PR DESCRIPTION
Apps could have more id entries in subsequent lines for navigation entries and more.

Currently the translations of several apps fail:
```
APP_ID="calendar
calendar"
RESOURCE_ID="calendar"
```