### PR TITLE
Allow slash in backport branches

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -65,7 +65,7 @@ do
   cd translationfiles/templates/
   for file in $(ls)
   do
-    mv $file ../../stable-templates/$version.$RESOURCE_ID.pot
+    mv $file ../../stable-templates/${version/\//-}.$RESOURCE_ID.pot
   done
   cd ../..
 done


### PR DESCRIPTION
Ref https://stackoverflow.com/questions/5928156/replace-one-character-with-another-in-bash

* integration_openproject broken with this commit: https://github.com/nextcloud/integration_openproject/commit/9f708e97efdfd932af361d6734f78d813936aa96

```
+ [ ! -f /app/.tx/config ]
+ sed -E s/<id>(.*)<\/id>/\1/
+ head --lines 1
+ grep -oE <id>.*</id> appinfo/info.xml
+ APP_ID=integration_openproject
+ sed -E s/\[nextcloud.(.*)\]/\1/
+ grep -oE \[nextcloud\..*\] .tx/config
+ RESOURCE_ID=integration_openproject
+ sed -E s/source_file\s*=\s*(.+)/\1/
+ grep -oE ^source_file\s*=\s*(.+)$ .tx/config
+ SOURCE_FILE=translationfiles/templates/integration_openproject.pot
+ [ integration_openproject = MYAPP ]
+ versions=stable22 stable23 stable24 master main
+ [ -f /app/.tx/backport ]
+ cat /app/.tx/backport
+ versions=release/2.0 master main
+ mkdir stable-templates
+ egrep ^\W*origin/release/2.0$
+ git branch -r
  origin/release/2.0
+ echo Valid branch
Valid branch
+ git checkout release/2.0
Switched to a new branch 'release/2.0'
Branch 'release/2.0' set up to track remote branch 'release/2.0' from 'origin'.
+ [ release/2.0 = stable22 ]
+ [ release/2.0 = stable23 ]
+ /translationtool.phar create-pot-files
Those files are ignored:
Array
(
    [0] => js/
)
+ [ release/2.0 = stable22 ]
+ [ release/2.0 = stable23 ]
+ cd translationfiles/templates/
+ ls
+ mv integration_openproject.pot ../../stable-templates/release/2.0.integration_openproject.pot
mv: cannot move 'integration_openproject.pot' to '../../stable-templates/release/2.0.integration_openproject.pot': No such file or directory
```