### PR TITLE
Fix script syntax

### DIFF
--- a/translations-desktop/handleDesktopTranslations.sh
+++ b/translations-desktop/handleDesktopTranslations.sh
@@ -18,7 +18,7 @@ mkdir /branches
 versions=$(git branch -r | grep "origin\/stable\-[0-9]\.[0-9]$" | cut -f2 -d"/")" master"
 
 # Allow to manually limit translations to specified backport branches within the repo
-if [[ -f '.tx/backport' ]]; then
+if [ -f '.tx/backport' ]; then
   versions="$(cat .tx/backport) master"
 fi
 
@@ -41,7 +41,7 @@ do
   git commit -am "[tx-robot] Update transifex configuration" -s || true
   git push origin $version
 
-  if [[ -f './resources.qrc' ]]; then
+  if [ -f './resources.qrc' ]; then
     resources="resources.qrc"
   else
     resources=""


### PR DESCRIPTION
```
+ [[ -f ./resources.qrc ]]
/handleTranslations.sh: 44: [[: not found
```

Signed-off-by: Joas Schilling <coding@schilljs.com>