### PR TITLE
Shallow-server now uses php 8.1

### DIFF
--- a/shallow-server/Dockerfile
+++ b/shallow-server/Dockerfile
@@ -1,19 +1,19 @@
-FROM debian:stable
+FROM debian:buster
 
 # Update repos install packages and cleanup
 # all in one step so we avoid large intermediate layers.
-RUN apt-get update && \ 
+RUN apt-get update && \
     apt-get install -y wget gnupg2 git libzip4 apt-transport-https lsb-release ca-certificates && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && \
-    apt-get install -y php7.4-cli php7.4-common php7.4-mbstring \
-    php7.4-gd php7.4-imagick php7.4-intl php7.4-bz2 php7.4-xml \
-    php7.4-mysql php7.4-zip php7.4-dev curl php7.4-curl \
-    php-dompdf php7.4-apcu redis-server php7.4-redis php7.4-smbclient \
-    php7.4-ldap unzip php7.4-pgsql php7.4-sqlite make apache2 \
-    php7.4-json php7.4-opcache libmagickcore-6.q16-2-extra \
-    libapache2-mod-php7.4 && \
+    apt-get install -y php8.1-cli php8.1-common php8.1-mbstring \
+    php8.1-gd php8.1-imagick php8.1-intl php8.1-bz2 php8.1-xml \
+    php8.1-mysql php8.1-zip php8.1-dev curl php8.1-curl \
+    php-dompdf php8.1-apcu redis-server php8.1-redis php8.1-smbclient \
+    php8.1-ldap unzip php8.1-pgsql php8.1-sqlite make apache2 \
+    php8.1-opcache libmagickcore-6.q16-2-extra \
+    libapache2-mod-php8.1 && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
After merge
- create a new tag: ghcr.io/nextcloud/continuous-integration-shallow-server-php8.1:1
- use it in https://github.com/AlvaroBrey/nextcloud-client-testing-server/pull/14

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>