### PR TITLE
Remove "pierre-alain-b rainloop-nextcloud" as it's deprecated

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -139,7 +139,6 @@
         "mwalbeck nextcloud-breeze-dark",
         "powerpaul17 nc_money",
         "paullereverend nextcloudextract",
-        "pierre-alain-b rainloop-nextcloud",
         "pulsejet memories",
         "Raudius files_scripts",
         "Rello analytics",


### PR DESCRIPTION
Signed-off-by: Joas Schilling <213943+nickvergessen@users.noreply.github.com>