### PR TITLE
Remove "nextcloud browser_warning" from sync

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -14,7 +14,6 @@
         "nextcloud approval",
         "nextcloud backup",
         "nextcloud bookmarks",
-        "nextcloud browser_warning",
         "nextcloud bruteforcesettings",
         "nextcloud calendar",
         "nextcloud circles",


### PR DESCRIPTION
Repo is archived https://github.com/nextcloud/browser_warning

Signed-off-by: Joas Schilling <213943+nickvergessen@users.noreply.github.com>