### PR TITLE
Add libmagickcore-6.q16-6-extra to enable SVG support in imagick

### DIFF
--- a/php8.0/Dockerfile
+++ b/php8.0/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https
     php8.0-cli php8.0-curl php8.0-pgsql php8.0-ldap \
     php8.0-sqlite php8.0-mysql php8.0-zip php8.0-xml \
     php8.0-redis php8.0-imagick php8.0-xdebug php8.0-apcu \
-    php8.0-mbstring make && \
+    php8.0-mbstring make libmagickcore-6.q16-2-extra && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>