### PR TITLE
fix(CI): Disable XDebug by default

### DIFF
--- a/php8.0/Dockerfile
+++ b/php8.0/Dockerfile
@@ -19,4 +19,5 @@ RUN curl -O -L https://getcomposer.org/download/1.10.15/composer.phar \
     && chmod +x composer.phar \
     && mv composer.phar /usr/local/bin/composer
 
+RUN phpdismod xdebug
 ADD nextcloud.ini /etc/php/8.0/cli/conf.d/nextcloud.ini


### PR DESCRIPTION
Following the PHP7.4 sample
https://github.com/nextcloud/docker-ci/blob/master/php7.4/Dockerfile#L31