### PR TITLE
Update phpunit to 9.5.28

### DIFF
--- a/php8.0/Dockerfile
+++ b/php8.0/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 RUN phpenmod zip intl gd systemd
-# Note: phpunit 9.5 contains breaking changes so we stick to the version before that
-RUN curl -O -L https://phar.phpunit.de/phpunit-9.4.4.phar \
-    && chmod +x phpunit-9.4.4.phar \
-    && mv phpunit-9.4.4.phar /usr/local/bin/phpunit
+
+RUN curl -O -L https://phar.phpunit.de/phpunit-9.5.28.phar \
+    && chmod +x phpunit-9.5.28.phar \
+    && mv phpunit-9.5.28.phar /usr/local/bin/phpunit
 RUN curl -O -L https://getcomposer.org/download/1.10.15/composer.phar \
     && chmod +x composer.phar \
     && mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
I think the crash I have with PHP 8.0 syntax comes from phpunit version being too old. We cannot stay behind for ever anyway, and the 9.4.4 phar cannot be used with PHP 8.1

Signed-off-by: Côme Chilliet <91878298+come-nc@users.noreply.github.com>