### PR TITLE
explicitly avoid fetching "de" broken language for desktop client

### DIFF
--- a/translations-desktop/handleDesktopTranslations.sh
+++ b/translations-desktop/handleDesktopTranslations.sh
@@ -77,7 +77,7 @@ do
   git checkout $version
 
   # pull translations
-  tx pull -f -a --minimum-perc=25
+  tx pull -f --minimum-perc=25 --language="af,ca,de_DE,en,es_CL,es_DO,es_HN,es,fa,gl,hu,it,lt_LT,nb_NO,pl,ro,sk,sv,TW,zh_HK,bg,cs,el,eo,es_CO,es_EC,es_MX,et,fi,he,id,ja,lv,nl,pt_BR,ru,sl,th,uk,zh_TW,br,da,en_GB,es_AR,es_CR,es_GT,es_SV,eu,fr,hr,is,ko,mk,oc,pt,sc,sr,tr,zh_CN"
 
   # create git commit and push it
   git add .


### PR DESCRIPTION
we regularly fetch "de" instead of "de_DE" (replaced by "de" in transifex desktop cleint config file)

so current situation is that randomly we get "de" after tx pull or we randomly get "de_DE" after tx pull

so we skip "de" locale in the call to tx pull

already got us a couple of broken releases