### PR TITLE
fix(l10n): Fix talk_desktop appid detection

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -25,6 +25,11 @@ if [ "$RESOURCE_ID" = "MYAPP" ]; then
   exit 2
 fi
 
+if [ "$RESOURCE_ID" = "talk_desktop" ]; then
+  # Desktop client has no appinfo/info.xml
+  APP_ID="talk_desktop"
+fi
+
 # TODO use build/l10nParseAppInfo.php to fetch app names for l10n
 
 versions='stable24 stable25 stable26 master main'


### PR DESCRIPTION
```
nextcloud.talk_desktop [zh_TW] - Done
+ [ talk_desktop =  ]
+ echo App id [] and transifex resource id [talk_desktop] mismatch
App id [] and transifex resource id [talk_desktop] mismatch
+ echo Renaming po files …
Renaming po files …
+ ls translationfiles
+ [ af = templates ]
```