### PR TITLE
Remove eslint image

### DIFF
--- a/eslint/Dockerfile
+++ b/eslint/Dockerfile
@@ -1,7 +1,0 @@
-FROM mhart/alpine-node:6.8.0
-# Sources at https://github.com/mhart/alpine-node
-# Version 6.8.0 contains npm 3.10.8
-
-MAINTAINER Joachim Bauch <mail@joachim-bauch.de>
-
-RUN npm install -g eslint@3.7.1

--- a/eslint/README.md
+++ b/eslint/README.md
@@ -1,3 +1,0 @@
-# eslint
-
-Minimal Docker image containing http://eslint.org/


### PR DESCRIPTION
This is an old version based on a deprecated image. I think this image is no longer used in any project because they install the package directly in CI and therefore I propose to just remove it.