### PR TITLE
switch build-test workflow to gihub hosted runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     outputs:
       matrix: ${{ steps.dockerfile.outputs.matrix }}


### PR DESCRIPTION
desktop client images fail to build on self hosted runners