### PR TITLE
only switch tthe build job for docker CI to github hosted runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     outputs:
       matrix: ${{ steps.dockerfile.outputs.matrix }}
@@ -36,7 +36,7 @@ jobs:
         echo "::set-output name=matrix::$FILES"
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: files
     
     strategy:


### PR DESCRIPTION
fix current state by having only teh failing job be using github hosted runners

other jobs run fine on self hosted runners