### PR TITLE
Revert #547 / Re-enable fractava/biblio translations

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -137,6 +137,7 @@
         "e-alfred nextcloud-scanner",
         "e-alfred ocdownloader",
         "eldertek duplicatefinder",
+        "fractava biblio",
         "gary-kim riotchat",
         "gino0631 nextcloud-metadata",
         "HomeITAdmin nextcloud_geoblocker",


### PR DESCRIPTION
In my repository the @nextcloud-bot was incorrectly configured as a repository collaborator with "Write" Permission level instead of the required "Admin" level, so @nickvergessen removed it.

The development on my repository was paused, so it didn't matter, but now I am continuing development and would like to have translation access again :)

I have corrected the setting, the bot now has Admin privileges in the repository.

See https://github.com/fractava/biblio/issues/282 and https://github.com/nextcloud/docker-ci/pull/547