### PR TITLE
fix(translations): Use main/master branch app description for transl…

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -32,9 +32,9 @@ fi
 
 # TODO use build/l10nParseAppInfo.php to fetch app names for l10n
 
-versions='stable26 stable27 stable28 master main'
+versions='main master stable28 stable27 stable26'
 if [ -f '/app/.tx/backport' ]; then
-  versions="$(cat /app/.tx/backport) master main"
+  versions="main master $(cat /app/.tx/backport)"
 fi
 
 # build POT files for all versions
@@ -111,9 +111,7 @@ else
   done
 fi
 
-# reverse version list to apply backports
-backportVersions=$(echo $versions | awk '{for(i=NF;i>=1;i--) printf "%s ", $i;print ""}')
-for version in $backportVersions
+for version in $versions
 do
   # skip if the branch doesn't exist
   if git branch -r | egrep "^\W*origin/$version$" ; then

--- a/translations/handleTranslations.sh
+++ b/translations/handleTranslations.sh
@@ -22,7 +22,7 @@ cd -
 
 # TODO use build/l10nParseAppInfo.php to fetch app names for l10n
 
-versions='stable26 stable27 stable28 master'
+versions='master stable28 stable27 stable26'
 
 # build POT files for all versions
 mkdir stable-templates
@@ -69,8 +69,7 @@ tx pull -a -f -r nextcloud.lib --minimum-perc=0
 # pull 20% of "settings" translations for the region name
 tx pull -a -f -r nextcloud.settings-1 --minimum-perc=20
 
-backportVersions=$(echo $versions | awk '{for(i=NF;i>=1;i--) printf "%s ", $i;print ""}')
-for version in $backportVersions
+for version in $versions
 do
   # skip if the branch doesn't exist
   if git branch -r | egrep "^\W*origin/$version$" ; then


### PR DESCRIPTION
…ations

Because we use `msgcat --use-first` we should have main/master as first so the app name, description, etc. are taken from that instead of the oldest version

Fix https://github.com/nextcloud/docker-ci/issues/607#issuecomment-1815812646