### PR TITLE
enh: Add image to run tests against webdav provided by apache

### DIFF
--- a/webdav-apache/Dockerfile
+++ b/webdav-apache/Dockerfile
@@ -1,0 +1,12 @@
+FROM httpd:alpine
+
+# Create webdav directory
+RUN mkdir -p /usr/local/apache2/webdav; chown www-data /usr/local/apache2/webdav
+# Copy config
+COPY ./webdav.conf /usr/local/apache2/conf/webdav.conf
+# Add password file
+RUN /usr/local/apache2/bin/htpasswd -cb /usr/local/apache2/webdav.password test pass
+RUN chown root:www-data /usr/local/apache2/webdav.password
+RUN chmod 640 /usr/local/apache2/webdav.password
+# Enable config
+RUN echo "Include conf/webdav.conf" >> /usr/local/apache2/conf/httpd.conf

--- a/webdav-apache/webdav.conf
+++ b/webdav-apache/webdav.conf
@@ -1,0 +1,19 @@
+LoadModule dav_module modules/mod_dav.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+
+Alias /webdav /usr/local/apache2/webdav
+
+<Location /webdav/>
+    DAV on
+    Options +Indexes
+    AuthType Basic
+    AuthName "webdav"
+    AuthUserFile /usr/local/apache2/webdav.password
+    Require valid-user
+</Location>
+
+<Directory /usr/local/apache2/webdav>
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>


### PR DESCRIPTION
Simple image to test apache provided webdav for `files_external`. (Use case: Drone -> Github migration).