### PR TITLE
fix: Switch to debian based apache image for webdav-apache

### DIFF
--- a/webdav-apache/Dockerfile
+++ b/webdav-apache/Dockerfile
@@ -1,7 +1,9 @@
-FROM httpd:alpine
+FROM httpd:latest
 
 # Create webdav directory
 RUN mkdir -p /usr/local/apache2/webdav; chown www-data /usr/local/apache2/webdav
+# Create lock DB directory
+RUN mkdir -p /usr/local/apache2/var; chown www-data /usr/local/apache2/var
 # Copy config
 COPY ./webdav.conf /usr/local/apache2/conf/webdav.conf
 # Add password file

--- a/webdav-apache/webdav.conf
+++ b/webdav-apache/webdav.conf
@@ -1,7 +1,9 @@
 LoadModule dav_module modules/mod_dav.so
 LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule dav_lock_module modules/mod_dav_lock.so
 
 Alias /webdav /usr/local/apache2/webdav
+DavLockDB "/usr/local/apache2/var/DavLock"
 
 <Location /webdav/>
     DAV on


### PR DESCRIPTION
Sorry for the invalid container, I messed up the IP while testing locally and connected to the wrong docker container thus not noticed it did not work.

The problem is that alpine image works, but not the WebDAV part, so we must use the debian based images instead (this time tested and works).

ref: https://gitlab.alpinelinux.org/alpine/aports/-/issues/13112
ref: https://github.com/docker-library/httpd/issues/201