### PR TITLE
feat: Add MySQL 8.4 (LTS) image

### DIFF
--- a/mysql-8.4/Dockerfile
+++ b/mysql-8.4/Dockerfile
@@ -1,0 +1,1 @@
+FROM mysql:8.4


### PR DESCRIPTION
Current LTS for MySQL (followup on 8.0) is now release: 8.4

So we should add this to our testing pipeline.