### PR TITLE
fix(shallow-server): remove fuse-overlayfs workarounds

### DIFF
--- a/shallow-server/Dockerfile
+++ b/shallow-server/Dockerfile
@@ -21,9 +21,7 @@ COPY opcache-recommended.ini /usr/local/etc/php/conf.d/
 
 WORKDIR /var/www/html
 
-# Looks like there's an issue on self-hosted runners with fuse-overlayfs that prevents us deleting the directory directly
-# so rename it first and then remove it
-RUN mv /var/www/html/ /var/www/html2/ && rm -rf /var/www/html2/
+RUN rm -rf /var/www/html
 RUN mkdir -p /var/www/html
 RUN chown www-data:www-data .
 

--- a/shallow-server/initnc.sh
+++ b/shallow-server/initnc.sh
@@ -5,11 +5,6 @@ export BRANCH=${BRANCH:=master}
 # Where we do all the work
 cd /var/www/html/
 
-# Run 'apt-get update' to unlock files. This seems neccessary on self hosted runners with fuse-overlayfs,
-# otherwise git checkout will error out with 'file exists' error. Needs to be run here, doesn't work when 
-# done inside the Dockerfile
-apt-get update
-
 # Update code
 su www-data -c "
 git fetch --force --depth 1 origin $BRANCH:refs/remotes/origin/$BRANCH


### PR DESCRIPTION
Basically reverts https://github.com/nextcloud/docker-ci/pull/594