### PR TITLE
feat: Add current mariadb LTS 11.4

### DIFF
--- a/mariadb-11.4/Dockerfile
+++ b/mariadb-11.4/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb:11.4


### PR DESCRIPTION
We should also test and support the current mariadb LTS which is 11.4