### PR TITLE
fix: Adjust base images to supported versions

### DIFF
--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https lsb-release ca-certificates && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https
     php8.2-cli php8.2-curl php8.2-pgsql php8.2-ldap \
     php8.2-sqlite php8.2-mysql php8.2-zip php8.2-xml \
     php8.2-redis php8.2-imagick php8.2-xdebug php8.2-apcu \
-    php8.2-mbstring make libmagickcore-6.q16-2-extra && \
+    php8.2-mbstring make libmagickcore-6.q16-6-extra && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https lsb-release ca-certificates && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget gnupg2 libzip4 apt-transport-https
     php8.3-cli php8.3-curl php8.3-pgsql php8.3-ldap \
     php8.3-sqlite php8.3-mysql php8.3-zip php8.3-xml \
     php8.3-redis php8.3-imagick php8.3-xdebug php8.3-apcu \
-    php8.3-mbstring make libmagickcore-6.q16-2-extra && \
+    php8.3-mbstring make libmagickcore-6.q16-6-extra && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
@@ -14,7 +14,7 @@ RUN phpenmod zip intl gd systemd
 RUN curl -O -L https://phar.phpunit.de/phpunit-9.5.28.phar \
     && chmod +x phpunit-9.5.28.phar \
     && mv phpunit-9.5.28.phar /usr/local/bin/phpunit
-RUN curl -O -L https://getcomposer.org/download/2.5.1/composer.phar \
+RUN curl -O -L https://getcomposer.org/download/2.7.7/composer.phar \
     && chmod +x composer.phar \
     && mv composer.phar /usr/local/bin/composer
 


### PR DESCRIPTION
- The first version of Nextcloud supporting PHP 8.2 was 26 which requires Bullseye as Debian version.
- The first version of Nextcloud supporting PHP 8.3 was 28 which requires Bookwork as Debian version.