### PR TITLE
build(build-test): Switch from `set-output` to `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
       id: dockerfile
       run: |
         FILES=$( echo '${{ steps.files.outputs.added_modified }}' | jq -c 'map(select(. | endswith("Dockerfile")))' )
-        echo "::set-output name=matrix::$FILES"
+        echo "matrix=$FILES" >> "$GITHUB_OUTPUT"
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #644