### PR TITLE
feat(images): Build multi-arch images

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,10 +5,12 @@ on:
     branches: [ master ]
     paths:
       - '*/Dockerfile'
+      - '.github/workflows/build-test.yml'
   pull_request:
     branches: [ master ]
     paths:
       - '*/Dockerfile'
+      - '.github/workflows/build-test.yml'      
 
 jobs:
   files:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0    
+
     - name: Build Docker image ${{ matrix.dockerfile }}
       run: |
         cd "$(dirname ${{ matrix.dockerfile }})"
-        docker build . --file Dockerfile
+        docker buildx build --platform linux/amd64,linux/arm64 . --file Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
@@ -58,6 +61,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           context: ${{ github.event.inputs.folderPath }}
           file: '${{ github.event.inputs.folderPath }}/${{ github.event.inputs.dockerFile }}'


### PR DESCRIPTION
Example run with changed Dockerfile: https://github.com/nextcloud/docker-ci/actions/runs/12613287202/job/35150961232#step:3:207

All runners now support `binfmt` that is needed to build multi-arch images (that support was missing back in August when the PR was created).