### PR TITLE
hostedtoolcache directory and environment variables for it

### DIFF
--- a/client-qt6/Dockerfile
+++ b/client-qt6/Dockerfile
@@ -256,3 +256,8 @@ RUN curl -sSLo /opt/sonar/build-wrapper-linux-x86.zip ${BUILD_WRAPPER_DOWNLOAD_U
           unzip -o /opt/sonar/build-wrapper-linux-x86.zip -d /opt/sonar/
 
 ENV PATH=/opt/sonar/build-wrapper-linux-x86:${PATH}
+
+# Install Python properly (e.g. for clang-tidy-pr-comments)
+ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+ENV RUNNER_TOOL_CACHE=/opt/hostedtoolcache
+RUN mkdir -p "${AGENT_TOOLSDIRECTORY}"


### PR DESCRIPTION
The clang-tidy check on the desktop client repository (and possible others) fails because the Python venv creation command does not find the `libpython` shared library. 

The reason is that `LD_LIBRARY_PATH` is not set to the `lib` subdirectory of the Python installation *and* that Python is not installed under `/opt/hostedtoolcache`. `LD_LIBRARY_PATH` cannot be set, because the venv creation command is in the `platisd/clang-tidy-pr-comments` action, so Python should be installed under `/opt/hostedtoolcache`. 

This can be achieved by setting the `AGENT_TOOLSDIRECTORY` and/or the `RUNNER_TOOL_CACHE` environment variables to this path in the `continuous-integration-client-qt6` image (used to run the clang-tidy check), which is what this patch does.
