### PR TITLE
Exclude client container from multi arch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,15 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0    
 
-    - name: Build Docker image ${{ matrix.dockerfile }}
+    # Only build non-client containers as multi-arch containers
+    - name: Build multi-arch Docker image ${{ matrix.dockerfile }}
+      if: ${{ !startsWith(matrix.dockerfile, 'client') }}
       run: |
         cd "$(dirname ${{ matrix.dockerfile }})"
         docker buildx build --platform linux/amd64,linux/arm64 . --file Dockerfile
+
+    - name: Build amd64 Docker image ${{ matrix.dockerfile }}
+      if: ${{ startsWith(matrix.dockerfile, 'client') }}
+      run: |
+        cd "$(dirname ${{ matrix.dockerfile }})"
+        docker build . --file Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build container image
         uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc # v6.11.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ startsWith(github.event.inputs.folderPath, 'client') && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: true
           context: ${{ github.event.inputs.folderPath }}
           file: '${{ github.event.inputs.folderPath }}/${{ github.event.inputs.dockerFile }}'


### PR DESCRIPTION
Client containers currently fail to build on arm64, therefore we exclude them from multi-arch builds for now.

Test run https://github.com/nextcloud/docker-ci/actions/runs/12910138025/job/35999490519?pr=712

Release workflow might need adjustments, but we will see.