### PR TITLE
Increased threshold for translations of iOS apps

### DIFF
--- a/translations/handleiOSNotesTranslations.sh
+++ b/translations/handleiOSNotesTranslations.sh
@@ -30,7 +30,7 @@ git checkout -- Source/Screens/Settings/en.lproj/Settings.strings
 tx push -s
 
 # pull translations
-tx pull -f -a --minimum-perc=25
+tx pull -f -a --minimum-perc=50
 
 
 # use de_DE instead of de

--- a/translations/handleiOSTranslations.sh
+++ b/translations/handleiOSTranslations.sh
@@ -28,7 +28,7 @@ git checkout -- Supporting\ Files/en.lproj
 tx push -s
 
 # pull translations
-tx pull -f -a --minimum-perc=0
+tx pull -f -a --minimum-perc=50
 
 cd Supporting\ Files
 


### PR DESCRIPTION
As discussed with @tobiasKaminsky, the Nextcloud app and Nextcloud Notes app for iOS should import translations only when they are at least 50 % translated. Based on the imported translations we can easily check which localizations to enable inside the Xcode project.