### PR TITLE
fix(shallow-server): ensure mod_env for strict password confirmation

### DIFF
--- a/shallow-server/run.sh
+++ b/shallow-server/run.sh
@@ -13,6 +13,7 @@ tail -f data/nextcloud.log &
 
 a2enmod ssl
 a2enmod headers
+a2enmod rewrite
 a2ensite default-ssl
 a2enconf ssl-params
 apache2ctl configtest


### PR DESCRIPTION
See our default [`htaccess`](https://github.com/nextcloud/server/blob/aa4a92451973edaa4ff53cb28ba471afb3ce5a39/.htaccess#L94), this is needed for the `Authorization` header to be handled 