### PR TITLE
add ios-plurals

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -209,7 +209,7 @@
     {
       "name": "ios",
       "arguments": [
-        ""
+        "nextcloud ios-plurals"
       ]
     },
     {


### PR DESCRIPTION
I am unsure, if this is correct.
It is for a ressource called "ios-plurals".
It is needed for ios app.

See https://github.com/nextcloud/ios/issues/3248