### PR TITLE
fix(translation): Notify on broken translations

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -158,6 +158,12 @@ if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '|' | wc -l) -ne 0 ]; 
   EXIT=4
 fi
 
+# Confirm English source does not contain the unicode single quote character
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' | wc -l) -ne 0 ]; then
+  echo "English source contains unicode single quote character, that should be replaced by normal single quotes" 1>&2
+  EXIT=4
+fi
+
 for file in $(ls l10n/*.json)
 do
   # Make sure only RTL languages contain such characters

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -143,67 +143,7 @@ do
 done
 
 # End of verbose mode
-set +x
+set +xe
 
-EXIT_CODE=0
-# Confirm German translation does not have the false "don't translate" warning
-if [ $(jq '.translations[]' l10n/de.json | grep 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' | wc -l) -ne 0 ]; then
-  echo "German language file contains the 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' hint." 1>&2
-  EXIT=3
-fi
-
-# Confirm English source does not contain the pipe character which breaks the Symfony Translation library
-if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '|' | wc -l) -ne 0 ]; then
-  echo "" 1>&2
-  echo "English source contains the pipe character" 1>&2
-  echo "---" 1>&2
-  jq '.translations | keys[]' l10n/en_GB.json | grep '|' 1>&2
-  EXIT=4
-fi
-
-# Confirm English source does not contain the unicode single quote character
-if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' | wc -l) -ne 0 ]; then
-  echo "" 1>&2
-  echo "English source contains unicode single quote character, that should be replaced by normal single quotes" 1>&2
-  echo "---" 1>&2
-  jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' 1>&2
-  EXIT=4
-fi
-
-# Confirm English source does not use triple dots
-if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' | wc -l) -ne 0 ]; then
-  echo "" 1>&2
-  echo "English source contains three consecutive dots. Unicode … should be used instead" 1>&2
-  echo "---" 1>&2
-  jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' 1>&2
-  EXIT=4
-fi
-
-# Check for leading or trailing spaces
-if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(^\"(\s|\\t|\\n)|(\s|\\t|\\n)\"$)' | wc -l) -ne 0 ]; then
-  echo "" 1>&2
-  echo "English source contains leading or trailing white spaces, tabs or new lines" 1>&2
-  echo "---" 1>&2
-  jq '.translations | keys[]' l10n/en_GB.json | grep -E '(^\"(\s|\\t|\\n)|(\s|\\t|\\n)\"$)' 1>&2
-  EXIT=4
-fi
-
-for file in $(ls l10n/*.json)
-do
-  # Make sure only RTL languages contain such characters
-  if [ "$file" != "l10n/ar.json" -a "$file" != "l10n/fa.json" -a "$file" != "l10n/he.json" -a "$file" != "l10n/ps.json" -a "$file" != "l10n/ug.json" -a "$file" != "l10n/ur_PK.json" ]; then
-    if [ $(jq '.translations[]' $file | grep -E '(\x{061C}|\x{0623}|\x{200E}|\x{200F}|\x{202A}|\x{202B}|\x{202C}|\x{202D}|\x{202E}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{206C}|\x{206D})' | wc -l) -ne 0 ]; then
-      echo "$file contains a RTL limited characters in the translations" 1>&2
-      EXIT=5
-    fi
-  fi
-
-  # Confirm translations do not contain the pipe character which breaks the Symfony Translation library
-  if [ $(jq '.translations[]' $file | grep '|' | wc -l) -ne 0 ]; then
-    echo "$file contains the pipe character" 1>&2
-    EXIT=6
-  fi
-done
-
-
-exit $EXIT_CODE
+/validateTranslationFiles.sh
+exit $?

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -141,3 +141,11 @@ do
 
   echo "done with $version"
 done
+
+# End of verbose mode
+set +x
+
+if [ $(jq '.translations[]' l10n/de.json | grep 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' | wc -l) -ne 0 ]; then
+  echo "German language file contains the 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' hint." 1>&2
+  exit 3
+fi

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -154,19 +154,37 @@ fi
 
 # Confirm English source does not contain the pipe character which breaks the Symfony Translation library
 if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '|' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
   echo "English source contains the pipe character" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep '|' 1>&2
   EXIT=4
 fi
 
 # Confirm English source does not contain the unicode single quote character
 if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
   echo "English source contains unicode single quote character, that should be replaced by normal single quotes" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' 1>&2
   EXIT=4
 fi
 
 # Confirm English source does not use triple dots
 if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
   echo "English source contains three consecutive dots. Unicode … should be used instead" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' 1>&2
+  EXIT=4
+fi
+
+# Check for leading or trailing spaces
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(^\"(\s|\\t|\\n)|(\s|\\t|\\n)\"$)' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
+  echo "English source contains leading or trailing white spaces, tabs or new lines" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep -E '(^\"(\s|\\t|\\n)|(\s|\\t|\\n)\"$)' 1>&2
   EXIT=4
 fi
 

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -145,7 +145,35 @@ done
 # End of verbose mode
 set +x
 
+EXIT_CODE=0
+# Confirm German translation does not have the false "don't translate" warning
 if [ $(jq '.translations[]' l10n/de.json | grep 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' | wc -l) -ne 0 ]; then
   echo "German language file contains the 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' hint." 1>&2
-  exit 3
+  EXIT=3
 fi
+
+# Confirm English source does not contain the pipe character which breaks the Symfony Translation library
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '|' | wc -l) -ne 0 ]; then
+  echo "English source contains the pipe character" 1>&2
+  EXIT=4
+fi
+
+for file in $(ls l10n/*.json)
+do
+  # Make sure only RTL languages contain such characters
+  if [ "$file" != "l10n/ar.json" -a "$file" != "l10n/fa.json" -a "$file" != "l10n/he.json" -a "$file" != "l10n/ps.json" -a "$file" != "l10n/ug.json" -a "$file" != "l10n/ur_PK.json" ]; then
+    if [ $(jq '.translations[]' $file | grep -E '(\x{061C}|\x{0623}|\x{200E}|\x{200F}|\x{202A}|\x{202B}|\x{202C}|\x{202D}|\x{202E}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{206C}|\x{206D})' | wc -l) -ne 0 ]; then
+      echo "$file contains a RTL limited characters in the translations" 1>&2
+      EXIT=5
+    fi
+  fi
+
+  # Confirm translations do not contain the pipe character which breaks the Symfony Translation library
+  if [ $(jq '.translations[]' $file | grep '|' | wc -l) -ne 0 ]; then
+    echo "$file contains the pipe character" 1>&2
+    EXIT=6
+  fi
+done
+
+
+exit $EXIT_CODE

--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -164,6 +164,12 @@ if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' | wc -l)
   EXIT=4
 fi
 
+# Confirm English source does not use triple dots
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' | wc -l) -ne 0 ]; then
+  echo "English source contains three consecutive dots. Unicode … should be used instead" 1>&2
+  EXIT=4
+fi
+
 for file in $(ls l10n/*.json)
 do
   # Make sure only RTL languages contain such characters

--- a/translations/Dockerfile
+++ b/translations/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p /app
 ADD gitconfig /root/.gitconfig
 ADD known_hosts /root/.ssh/known_hosts
 ADD handleTranslations.sh /handleTranslations.sh
+ADD validateTranslationFiles.sh /validateTranslationFiles.sh
 ADD translationtool/translationtool.phar /translationtool.phar
 
 WORKDIR /app

--- a/translations/handleAppsTranslations.sh
+++ b/translations/handleAppsTranslations.sh
@@ -62,3 +62,14 @@ done
 git commit -m "Fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"
+
+set +xe
+
+EXIT_CODE=0
+for app in $(ls .)
+do
+  if [ -d "$app/l10n" ]; then
+    /validateTranslationFiles.sh $app
+    EXIT_CODE=$(($?+$EXIT_CODE))
+  fi
+done;

--- a/translations/handleTranslations.sh
+++ b/translations/handleTranslations.sh
@@ -103,3 +103,18 @@ do
 
   echo "done with $version"
 done
+
+set +xe
+EXIT_CODE=0
+/validateTranslationFiles.sh core
+EXIT_CODE=$(($?+$EXIT_CODE))
+/validateTranslationFiles.sh lib
+EXIT_CODE=$(($?+$EXIT_CODE))
+
+for app in $(ls apps)
+do
+  if [ -d "apps/$app/l10n" ]; then
+    /validateTranslationFiles.sh apps/$app
+    EXIT_CODE=$(($?+$EXIT_CODE))
+  fi
+done;

--- a/translations/validateTranslationFiles.sh
+++ b/translations/validateTranslationFiles.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+cd $1
+
+EXIT_CODE=0
+# Confirm German translation does not have the false "don't translate" warning
+if [ $(jq '.translations[]' l10n/de.json | grep 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' | wc -l) -ne 0 ]; then
+  echo "German language file $1/l10n/de.json contains the 'Benötigt keine Übersetzung. Hier wird nur die formelle Übersetzung verwendet (de_DE).' hint." 1>&2
+  EXIT_CODE=3
+fi
+
+# Confirm English source does not contain the pipe character which breaks the Symfony Translation library
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '|' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
+  echo "English source $1/l10n/en_GB.json contains the pipe character" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep '|' 1>&2
+  EXIT_CODE=4
+fi
+
+# Confirm English source does not contain the unicode single quote character
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
+  echo "English source $1/l10n/en_GB.json contains unicode single quote character, that should be replaced by normal single quotes" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep -E '(´|’)' 1>&2
+  EXIT_CODE=4
+fi
+
+# Confirm English source does not use triple dots
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
+  echo "English source $1/l10n/en_GB.json contains three consecutive dots. Unicode … should be used instead" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep '\.\.\.' 1>&2
+  EXIT_CODE=4
+fi
+
+# Check for leading or trailing spaces
+if [ $(jq '.translations | keys[]' l10n/en_GB.json | grep -E '(^\"(\s|\\t|\\n)|(\s|\\t|\\n)\"$)' | wc -l) -ne 0 ]; then
+  echo "" 1>&2
+  echo "English source $1/l10n/en_GB.json contains leading or trailing white spaces, tabs or new lines" 1>&2
+  echo "---" 1>&2
+  jq '.translations | keys[]' l10n/en_GB.json | grep -E '(^\"(\s|\\t|\\n)|(\s|\\t|\\n)\"$)' 1>&2
+  EXIT_CODE=4
+fi
+
+for file in $(ls l10n/*.json)
+do
+  # Make sure only RTL languages contain such characters
+  if [ "$file" != "l10n/ar.json" -a "$file" != "l10n/fa.json" -a "$file" != "l10n/he.json" -a "$file" != "l10n/ps.json" -a "$file" != "l10n/ug.json" -a "$file" != "l10n/ur_PK.json" ]; then
+    if [ $(jq '.translations[]' $file | grep -E '(\x{061C}|\x{0623}|\x{200E}|\x{200F}|\x{202A}|\x{202B}|\x{202C}|\x{202D}|\x{202E}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{206C}|\x{206D})' | wc -l) -ne 0 ]; then
+      echo "$1/$file contains a RTL limited characters in the translations" 1>&2
+      EXIT_CODE=5
+    fi
+  fi
+
+  # Confirm translations do not contain the pipe character which breaks the Symfony Translation library
+  if [ $(jq '.translations[]' $file | grep '|' | wc -l) -ne 0 ]; then
+    echo "$1/$file contains the pipe character" 1>&2
+    EXIT_CODE=6
+  fi
+done
+
+cd -
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Check translations aka. Notify translation crew
- [x] Warn about german translation mistakes
- [ ] Make work for server and others
- [x] Check RTL characters in non-RTL languages https://github.com/nextcloud/server/blob/0fc355aa1e8767c27c934e9ac3259910fb659c29/build/translation-checker.php#L85-L88
- [x] Check for `|` in *translation*: https://github.com/nextcloud/server/blob/0fc355aa1e8767c27c934e9ac3259910fb659c29/build/translation-checker.php#L92-L95

## Check source aka. Raise an issue for the maintainers to fix
- [x] Check for `|` in **source**: https://github.com/nextcloud/server/blob/0fc355aa1e8767c27c934e9ac3259910fb659c29/build/translation-checker.php#L92-L95
- [x] Check for `’` or `´` in en_GB: https://github.com/nextcloud/server/blob/0fc355aa1e8767c27c934e9ac3259910fb659c29/build/translation-checker.php#L103-L111
- [x] Check for `...` instead of `…` in **source**: https://github.com/nextcloud/server/blob/0fc355aa1e8767c27c934e9ac3259910fb659c29/build/triple-dot-checker.php#L23 
See https://github.com/nextcloud/server/pull/20321 as well
- [x] Check for leading or trailing spaces of strings