### PR TITLE
Remove sync of deprecated app integration_twitter

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -75,7 +75,6 @@
         "nextcloud integration_reddit",
         "nextcloud integration_replicate",
         "nextcloud integration_tmdb",
-        "nextcloud integration_twitter",
         "nextcloud integration_zammad",
         "nextcloud integration_zulip",
         "nextcloud jitsi",


### PR DESCRIPTION
App is actually dead.

See discussion at https://github.com/nextcloud/server/issues/50841

Already locked related resource at Transifex minutes ago.