### PR TITLE
Removed translation threshold for language import

### DIFF
--- a/translations/handleiOSNotesTranslations.sh
+++ b/translations/handleiOSNotesTranslations.sh
@@ -29,7 +29,7 @@ git checkout -- Source/Screens/Settings/en.lproj/Settings.strings
 tx push -s
 
 # pull translations
-tx pull -f -a --minimum-perc=50
+tx pull -f -a
 
 
 # use de_DE instead of de

--- a/translations/handleiOSTranslations.sh
+++ b/translations/handleiOSTranslations.sh
@@ -29,7 +29,7 @@ git checkout -- Supporting\ Files/en.lproj
 tx push -s
 
 # pull translations
-tx pull -f -a --minimum-perc=50
+tx pull -f -a
 
 cd Supporting\ Files
 


### PR DESCRIPTION
As it surfaced today, the translation update process breaks builds of our iOS projects as soon as any translation sinks below 50% because its files get removed but still are explicitly referenced from the Xcode project (that's how Xcode projects work). To decouple our capability to build our apps from the availability of translations, the threshold must be removed again.

FYI, @tobiasKaminsky.

Please run the translation update once manually, @nickvergessen.