### PR TITLE
fix: Use angular style for conventional commits

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -54,7 +54,7 @@ do
   tx migrate
   git add --force .tx/config
   rm .tx/config_*
-  git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+  git commit -am "fix(l10n): Update Transifex configuration" -s || true
   git push
 
   # build POT files
@@ -136,7 +136,7 @@ do
 
   # create git commit and push it
   git add l10n/*.js l10n/*.json
-  git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+  git commit -am "fix(l10n): Update translations from Transifex" -s || true
   git push origin $version
 
   echo "done with $version"

--- a/translations-desktop/handleDesktopTranslations.sh
+++ b/translations-desktop/handleDesktopTranslations.sh
@@ -40,7 +40,7 @@ do
   tx migrate
   git add .tx/config
   rm .tx/config_*
-  git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+  git commit -am "fix(l10n): Update Transifex configuration" -s || true
   git push origin $version
 
   if [[ -f './resources.qrc' ]]; then
@@ -88,7 +88,7 @@ do
 
   # create git commit and push it
   git add .
-  git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+  git commit -am "fix(l10n): Update translations from Transifex" -s || true
   git push origin $version
   echo "done with $version"
 done

--- a/translations/handleAppsTranslations.sh
+++ b/translations/handleAppsTranslations.sh
@@ -25,7 +25,7 @@ do
   tx migrate
   git add .tx/config
   rm .tx/config_*
-  git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+  git commit -am "fix(l10n): Update Transifex configuration" -s || true
   git push
 
 
@@ -59,7 +59,7 @@ do
 done
 
 # create git commit and push it
-git commit -m "Fix(l10n): Update translations from Transifex" -s || true
+git commit -m "fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"
 

--- a/translations/handleAppstoreTranslations.sh
+++ b/translations/handleAppstoreTranslations.sh
@@ -21,7 +21,7 @@ pip3 install Django==1.9.8
 tx migrate
 git add .tx/config
 rm .tx/config_*
-git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+git commit -am "fix(l10n): Update Transifex configuration" -s || true
 git push origin master
 
 # push sources
@@ -38,6 +38,6 @@ rm -rf locale/ug/
 
 # create git commit and push it
 git add locale/
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleChangelogServerTranslations.sh
+++ b/translations/handleChangelogServerTranslations.sh
@@ -19,7 +19,7 @@ cd /app
 tx migrate
 git add .tx/config
 rm .tx/config_*
-git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+git commit -am "fix(l10n): Update Transifex configuration" -s || true
 git push
 cd -
 
@@ -34,6 +34,6 @@ php /translationtool/generate-xml.php /app/data/
 
 # create git commit and push it
 git add .
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleExternalBranchedAndroidTranslations.sh
+++ b/translations/handleExternalBranchedAndroidTranslations.sh
@@ -18,7 +18,7 @@ git checkout -B $3
 tx migrate
 git add .tx/config
 rm .tx/config_*
-git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+git commit -am "fix(l10n): Update Transifex configuration" -s || true
 git push -f origin $3
 
 # push sources
@@ -35,6 +35,6 @@ fi
 
 # create git commit and push it
 git add .
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push -f origin $3
 echo "done"

--- a/translations/handlePlainTranslations.sh
+++ b/translations/handlePlainTranslations.sh
@@ -203,11 +203,11 @@ do
   # create git commit and push it
 #  if [ $1 = "nextcloud" -a $2 = "talk-android" ]; then
 #    git add .
-#    git commit -am "Fix(l10n): Update translations from Transifex" -s || true
-#    gh pr create -t "Fix(l10n): Update translations from Transifex" --base $version --body ""
+#    git commit -am "fix(l10n): Update translations from Transifex" -s || true
+#    gh pr create -t "fix(l10n): Update translations from Transifex" --base $version --body ""
 #  else
     git add .
-    git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+    git commit -am "fix(l10n): Update translations from Transifex" -s || true
     git push origin $version
     echo "done"
 #  fi

--- a/translations/handleTranslations.sh
+++ b/translations/handleTranslations.sh
@@ -16,7 +16,7 @@ cd /app
 tx migrate
 git add .tx/config
 rm .tx/config_*
-git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+git commit -am "fix(l10n): Update Transifex configuration" -s || true
 git push
 cd -
 
@@ -98,7 +98,7 @@ do
   # create git commit and push it
   git add apps core lib
 
-  git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+  git commit -am "fix(l10n): Update translations from Transifex" -s || true
   git push origin $version
 
   echo "done with $version"

--- a/translations/handleWindowsPhoneAppTranslations.sh
+++ b/translations/handleWindowsPhoneAppTranslations.sh
@@ -20,6 +20,6 @@ tx pull -f -a --minimum-perc=75
 
 # create git commit and push it
 git add .
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleiOSNotesTranslations.sh
+++ b/translations/handleiOSNotesTranslations.sh
@@ -47,6 +47,6 @@ mv Source/Screens/Settings/de_DE.lproj/Settings.strings Source/Screens/Settings/
 
 # create git commit and push it
 git add .
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push origin develop
 echo "done"

--- a/translations/handleiOSTalkTranslations.sh
+++ b/translations/handleiOSTalkTranslations.sh
@@ -15,7 +15,7 @@ git clone git@github.com:nextcloud/talk-ios /app
 tx migrate
 git add .tx/config
 rm .tx/config_*
-git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+git commit -am "fix(l10n): Update Transifex configuration" -s || true
 git push
 
 # remove all translations (they are added afterwards anyways but allows to remove languages via transifex)
@@ -39,6 +39,6 @@ cd ..
 
 # create git commit and push it
 git add .
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"

--- a/translations/handleiOSTranslations.sh
+++ b/translations/handleiOSTranslations.sh
@@ -18,7 +18,7 @@ cd iOSClient
 tx migrate
 git add .tx/config
 rm .tx/config_*
-git commit -am "Fix(l10n): Update Transifex configuration" -s || true
+git commit -am "fix(l10n): Update Transifex configuration" -s || true
 git push
 
 # remove all translations (they are added afterwards anyways but allows to remove languages via transifex)
@@ -41,6 +41,6 @@ cd ..
 
 # create git commit and push it
 git add .
-git commit -am "Fix(l10n): Update translations from Transifex" -s || true
+git commit -am "fix(l10n): Update translations from Transifex" -s || true
 git push origin master
 echo "done"


### PR DESCRIPTION
Many tools take the angular preset as default for conventional commit checks. This means that commit types have to be all lower case.

L10n updates do not follow the preset, so they are skipped by ``TriPSs/conventional-changelog-action``.