### PR TITLE
fix(translations-desktop): also pull source file

### DIFF
--- a/translations-desktop/handleDesktopTranslations.sh
+++ b/translations-desktop/handleDesktopTranslations.sh
@@ -79,6 +79,8 @@ do
   git checkout $version
 
   # pull translations
+  # -a/--all does not include the source file, so this needs to be pulled separately (required for plural forms to work)
+  tx pull --source --translations --languages en --force nextcloud.client
   tx pull -f --minimum-perc=25 -a
 
   rm -rf translations/client_de.ts


### PR DESCRIPTION
`-a` / `--all` does not include the source language apparently.

This is required to make plural forms (e.g. *1 file*, *5 files*) work correctly when using the `en` translation.