### PR TITLE
fix(translationtool): include only .po translation files for ExApps

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -138,9 +138,9 @@ do
   # create git commit and push it
   git add l10n/*.js l10n/*.json
 
-  # for ExApps, we need to include .po,.mo translation files as well
+  # for ExApps, we need to include .po translation files as well
   if [ "$IS_EX_APP" = "true" ]; then
-    git add translationfiles/*.po translationfiles/*.mo
+    git add translationfiles/*.po
   fi
 
   git commit -am "fix(l10n): Update translations from Transifex" -s || true


### PR DESCRIPTION
Fix up for: https://github.com/nextcloud/docker-ci/pull/629

Include only `.po` translations files - `.mo` files can be compiled from `.po` files when needed.