### PR TITLE
Disabled translation sync for deprecated sharerenamer app

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -157,7 +157,6 @@
         "janis91 ocr",
         "janis91 pdf_tailor",
         "jgraph drawio-nextcloud",
-        "JonathanTreffler sharerenamer",
         "julien-nc integration_dropbox",
         "julien-nc integration_excalidraw",
         "julien-nc integration_mattermost",


### PR DESCRIPTION
The sharerenamer app is no longer needed (see https://github.com/JonathanTreffler/sharerenamer/issues/340) and I just archived the repository.