### PR TITLE
Fix(SwiftNextcloudUI): Disable automatic translations push for now.

### DIFF
--- a/translations/handleSwiftNextcloudUITranslations.sh
+++ b/translations/handleSwiftNextcloudUITranslations.sh
@@ -14,9 +14,6 @@ gpg --list-keys
 # fetch git repo
 git clone git@github.com:nextcloud/swiftnextcloudui /app
 
-# push sources
-tx push -s
-
 # pull translations
 tx pull -f -a
 


### PR DESCRIPTION
Commit message:
> Transifex currently overwrites all online translations for every language when an Xcode string catalog is pushed. Hence the update should work only in direction from Transifex to the project repository until we figured out a solution to safely update the online keys without such loss. Without this commit, we currently have no automated updates at all.