### PR TITLE
chore(server): Bump PHP in server image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:bookworm
 
 # Update repos install packages and cleanup
 # all in one step so we avoid large intermediate layers.
@@ -7,13 +7,13 @@ RUN apt-get update && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && \
-    apt-get install -y php8.1-cli php8.1-common php8.1-mbstring \
-    php8.1-gd php8.1-imagick php8.1-intl php8.1-bz2 php8.1-xml \
-    php8.1-mysql php8.1-zip php8.1-dev curl php8.1-curl \
-    php-dompdf php8.1-apcu redis-server php8.1-redis php8.1-smbclient \
-    php8.1-ldap unzip php8.1-pgsql php8.1-sqlite make apache2 \
-    php8.1-opcache libmagickcore-6.q16-2-extra \
-    libapache2-mod-php8.1 && \
+    apt-get install -y php8.2-cli php8.2-common php8.2-mbstring \
+    php8.2-gd php8.2-imagick php8.2-intl php8.2-bz2 php8.2-xml \
+    php8.2-mysql php8.2-zip php8.2-dev curl php8.2-curl \
+    php-dompdf php8.2-apcu redis-server php8.2-redis php8.2-smbclient \
+    php8.2-ldap unzip php8.2-pgsql php8.2-sqlite make apache2 \
+    php8.2-opcache libmagickcore-6.q16-2-extra \
+    libapache2-mod-php8.2 && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
@tobiasKaminsky The image seems to be from you? It can no longer build as the full server repo with history is too big to be cloned in the builders

https://github.com/nextcloud/docker-ci/actions/runs/18195103803/job/51799192838?pr=829

```
System.IO.IOException: Disk quota exceeded : '/home/runner/actions-runner/_diag/Worker_20251002-135305-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
```