### PR TITLE
fix(transifex): Stop translating old / unreleased apps

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -35,18 +35,21 @@ git push
 ##################################
 # Validate sync setup
 ##################################
-APP_MAX_VERSION=$(grep -oE '<nextcloud.*max-version=".*".*>' appinfo/info.xml | head --lines 1 | sed -E 's/(.*)max-version="(.*)"(.*)/\2/')
-if [ ! $APP_MAX_VERSION ]; then
-  echo "App has no max-version defined"
-  grep '<nextcloud' appinfo/info.xml | head --lines 1
-  exit 1
-elif [ $APP_MAX_VERSION -lt 30 ]; then
-  echo "App was not released in the last year and translations should be stopped"
-  echo "Defined max-version is $APP_MAX_VERSION"
-  exit 1
-fi
+DAY_OF_WEEK=$(date "+%w")
+if [ $DAY_OF_WEEK -eq 6 ]; then
+  APP_MAX_VERSION=$(grep -oE '<nextcloud.*max-version=".*".*>' appinfo/info.xml | head --lines 1 | sed -E 's/(.*)max-version="(.*)"(.*)/\2/')
+  if [ ! $APP_MAX_VERSION ]; then
+    echo "App has no max-version defined"
+    grep '<nextcloud' appinfo/info.xml | head --lines 1
+    exit 1
+  elif [ $APP_MAX_VERSION -lt 30 ]; then
+    echo "App was not released in the last year and translations should be stopped"
+    echo "Defined max-version is $APP_MAX_VERSION"
+    exit 1
+  fi
 
-echo "App has max-version $APP_MAX_VERSION"
+  echo "App has max-version $APP_MAX_VERSION"
+fi
 
 APP_ID=$(grep -oE '<id>.*</id>' appinfo/info.xml | head --lines 1 | sed -E 's/<id>(.*)<\/id>/\1/')
 IS_EX_APP=$(grep -q '<external-app>' appinfo/info.xml && grep -q '</external-app>' appinfo/info.xml && echo "true" || echo "false")


### PR DESCRIPTION
- Translations are only useful when they reach endusers
- I came across https://github.com/nextcloud/files_filter
- The app was recently translated into be
- The last useful commit release was 8 years ago
- The app is not in the appstore: https://apps.nextcloud.com/apps/files_filter
- Last compatible version was 13 https://github.com/nextcloud/files_filter/blob/master/appinfo/info.xml#L13

So I now add a small sanity check:
- When the max-version (required to be listed as compatible in the appstore), is lower than the oldest still supported Nextcloud version, we no longer translate the app
- Currently this goes via the error-case email to @tobiasKaminsky and @nickvergessen 
- Afterwards we:
  - Send a PR to remove them from translations/config.json
  - Document in https://help.nextcloud.com/t/list-of-resources-and-their-priority-for-translation/78312 that the app is no longer translated
  - Either we or @rakekniven disables the resource on transifex


---

Message template
```markdown
# Translations are paused

Hi there,

we currently paused the translation sync of this app, as it seems the app was not released for any of the currently supported versions of Nextcloud. Translations are only useful, if they get released and shipped to users.
Otherwise we want to save the efforts of translators and focus on apps that are still actively maintained and released.

If you find the time again to update the app:
- [ ] Increase the `max-version`  in `appinfo/info.xml` to at least Nextcloud 31 (currently the oldest still supported version). Of course it would be even better to also support the currently newest version 32 and the upcoming development version 33 already, but that is not required at this point to get translations re-enabled.
- [ ] Afterwards create an issue over at https://github.com/nextcloud/docker-ci/issues/new?template=BLANK_ISSUE so we can unlock the translation resource again and notify the translators

Thanks for your work in the past and hopefully we hear from you soon.
cheers the Nextcloud Translations Team
```