### PR TITLE
enh: offer LDAP with TLS and a self-signed cert

### DIFF
--- a/openldap/Dockerfile
+++ b/openldap/Dockerfile
@@ -2,15 +2,15 @@
 # simplified to our needs to due https://github.com/dinkel/docker-openldap/issues/21
 # (Proposed my solution in https://github.com/dinkel/docker-openldap/issues/21#issuecomment-468839994)
 
-FROM debian:buster-slim
+FROM debian:trixie-slim
 
 MAINTAINER Arthur Schiwon <blizzz@arthur-schiwon.de>
 
-ENV OPENLDAP_VERSION 2.4.47
+ENV OPENLDAP_VERSION 2.6.10
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-        slapd=${OPENLDAP_VERSION}* ldap-utils=${OPENLDAP_VERSION}* libldap-common=${OPENLDAP_VERSION}* && \
+        slapd=${OPENLDAP_VERSION}* ldap-utils=${OPENLDAP_VERSION}* libldap-common=${OPENLDAP_VERSION}* gnutls-bin && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -18,6 +18,7 @@ RUN mv /etc/ldap /etc/ldap.dist
 
 COPY modules/ /etc/ldap.dist/modules
 COPY LDIFs/* /etc/ldap/prepopulate/
+COPY certificate/ /tmp/certificate
 
 RUN cp -r /etc/ldap.dist/* /etc/ldap
 
@@ -25,16 +26,28 @@ COPY slapf_config /tmp/slapd_config
 RUN debconf-set-selections /tmp/slapd_config \
     && dpkg-reconfigure -f noninteractive slapd \
     && rm /tmp/slapd_config \
-    && sed -i "s/^#BASE.*/BASE c=nextcloud,dc=ci/g" /etc/ldap/ldap.conf \
-    && slapadd -n0 -F /etc/ldap/slapd.d -l "/etc/ldap/modules/memberof.ldif" \
-    && chown -R openldap:openldap /etc/ldap/slapd.d/ /var/lib/ldap/ /var/run/slapd/
+    && sed -i "s/^#BASE.*/BASE c=nextcloud,dc=ci/g" /etc/ldap/ldap.conf
+
+RUN slapadd -v -n0 -F /etc/ldap/slapd.d -l "/etc/ldap/modules/memberof.ldif"
+
+# create a self-signed certificate
+RUN mkdir /etc/ldap/cert/ \
+	&& cd /etc/ldap/cert \
+	&& certtool --generate-privkey --outfile ca.key \
+	&& certtool --generate-self-signed --load-privkey ca.key --outfile ca.crt \
+	   --template /tmp/certificate/template \
+	&& chown -R openldap:openldap /etc/ldap/cert \
+	&& slapmodify -v -n0 -F /etc/ldap/slapd.d -l "/tmp/certificate/config.ldif"
+
+RUN mkdir /var/run/slapd
+RUN chown -R openldap:openldap /etc/ldap/slapd.d/ /var/lib/ldap/ /var/run/slapd
 
 COPY entrypoint.sh /entrypoint.sh
 
-EXPOSE 389
+EXPOSE 389 636
 
 VOLUME ["/etc/ldap", "/var/lib/ldap"]
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["slapd", "-d", "32768", "-u", "openldap", "-g", "openldap"]
+CMD ["slapd", "-d", "32768", "-u", "openldap", "-g", "openldap", "-h", "ldaps:/// ldap:/// ldapi:///"]

--- a/openldap/certificate/config.ldif
+++ b/openldap/certificate/config.ldif
@@ -1,0 +1,7 @@
+dn: cn=config
+changetype: modify
+replace: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/ldap/cert/ca.crt
+-
+replace: olcTLSCertificateKeyFile
+olcTLSCertificateKeyFile: /etc/ldap/cert/ca.key

--- a/openldap/certificate/template
+++ b/openldap/certificate/template
@@ -1,0 +1,4 @@
+organization = "Nextcloud"
+cn = "nextcloud.ci"
+serial = 42
+expiration_days = 18250

--- a/openldap/modules/memberof.ldif
+++ b/openldap/modules/memberof.ldif
@@ -1,11 +1,10 @@
 dn: cn=module,cn=config
 cn: module
 objectClass: olcModuleList
-objectClass: top
 olcModulePath: /usr/lib/ldap
 olcModuleLoad: memberof.la
 
-dn: olcOverlay={0}memberof,olcDatabase={1}hdb,cn=config
+dn: olcOverlay=memberof,olcDatabase={1}mdb,cn=config
 objectClass: olcConfig
 objectClass: olcMemberOf
 objectClass: olcOverlayConfig
@@ -20,14 +19,16 @@ olcMemberOfMemberOfAD: memberOf
 dn: cn=module,cn=config
 cn: module
 objectClass: olcModuleList
-objectClass: top
 olcModulePath: /usr/lib/ldap
 olcModuleLoad: refint.la
 
-dn: olcOverlay={1}refint,olcDatabase={1}hdb,cn=config
+dn: olcOverlay=refint,olcDatabase={1}mdb,cn=config
 objectClass: olcConfig
 objectClass: olcOverlayConfig
 objectClass: olcRefintConfig
 objectClass: top
-olcOverlay: {1}refint
-olcRefintAttribute: memberof member manager owner
+olcOverlay: refint
+olcRefintAttribute: memberof
+olcRefintAttribute: member
+olcRefintAttribute: manager
+olcRefintAttribute: owner


### PR DESCRIPTION
- uses certtool to create a self-signed cert
- … and configured openldap accordingly
- exposes port 636
- includes also:
  - bumps to a current Debian and OpenLDAP
  - deprecation fixes

Intended is to extend test around some TLS checks. 