### PR TITLE
fix(transifex): Fix talk_desktop by defining the resource earlier

### DIFF
--- a/translations-app/handleAppTranslations.sh
+++ b/translations-app/handleAppTranslations.sh
@@ -36,6 +36,8 @@ git push
 # Validate sync setup
 ##################################
 DAY_OF_WEEK=$(date "+%w")
+RESOURCE_ID=$(grep -oE '\[o:nextcloud:p:nextcloud:r:.*\]' .tx/config | sed -E 's/\[o:nextcloud:p:nextcloud:r:(.*)\]/\1/')
+
 if [ "$RESOURCE_ID" = "talk_desktop" ]; then
   echo "Skipping release check of Talk Desktop"
 elif [ $DAY_OF_WEEK -eq 6 ]; then
@@ -55,7 +57,6 @@ fi
 
 APP_ID=$(grep -oE '<id>.*</id>' appinfo/info.xml | head --lines 1 | sed -E 's/<id>(.*)<\/id>/\1/')
 IS_EX_APP=$(grep -q '<external-app>' appinfo/info.xml && grep -q '</external-app>' appinfo/info.xml && echo "true" || echo "false")
-RESOURCE_ID=$(grep -oE '\[o:nextcloud:p:nextcloud:r:.*\]' .tx/config | sed -E 's/\[o:nextcloud:p:nextcloud:r:(.*)\]/\1/')
 SOURCE_FILE=$(grep -oE '^source_file\s*=\s*(.+)$' .tx/config | sed -E 's/source_file\s*=\s*(.+)/\1/')
 
 if [ "$RESOURCE_ID" = "MYAPP" ]; then


### PR DESCRIPTION
Current problem:
```
+ date +%w
+ DAY_OF_WEEK=6
+ [  = talk_desktop ]
+ [ 6 -eq 6 ]
+ sed -E s/(.*)max-version="(.*)"(.*)/\2/
+ head --lines 1
+ grep -oE <nextcloud.*max-version=".*".*> appinfo/info.xml
+ APP_MAX_VERSION=
+ [ !App has no max-version defined
 ]
+ echo App has no max-version defined
+ head --lines 1
+ grep <nextcloud appinfo/info.xml
+ exit 1
```