### PR TITLE
fix: Stop translating archived repo cloud-py-api/cloud_py_api

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -134,7 +134,6 @@
 				"callmemagnus nextcloud-searchpage",
 				"chenasraf nextcloud-autocurrency",
 				"chenasraf nextcloud-forum",
-				"cloud-py-api cloud_py_api",
 				"CollaboraOnline richdocumentscode",
 				"cwilby nextcloud-workflow-media-converter",
 				"eldertek duplicatefinder",


### PR DESCRIPTION
> ERROR: This repository was archived so it is read-only.
fatal: Could not read from remote repository.