### PR TITLE
fix(clang-tidy): for the desktop client clang-tidy CI check

### DIFF
--- a/client-qt6/Dockerfile
+++ b/client-qt6/Dockerfile
@@ -14,6 +14,7 @@ RUN \
         perl \
         python3 \
         python3-pip \
+        python3.13-venv \
         build-essential \
         mesa-common-dev \
         pkg-config \


### PR DESCRIPTION
to be able to post clang-tidy comments during CI on desktop client PR checks, we need python venv package