### PR TITLE
feat(desktop/appimage): upgrade the craft commit we depend on, build with Qt 6.10.2

### DIFF
--- a/client-appimage-qt6/Dockerfile.el8
+++ b/client-appimage-qt6/Dockerfile.el8
@@ -67,7 +67,7 @@ RUN \
 
 ADD craftmaster.ini /root/craftmaster.ini
 
-ENV CRAFT_IMAGE "linux-gcc-x86_64-qt6.10.1-20260204.tar.gz"
+ENV CRAFT_IMAGE "linux-gcc-x86_64-qt6.10.2-20260219.tar.gz"
 
 RUN \
     wget https://download.nextcloud.com/desktop/development/qt/${CRAFT_IMAGE} && \

--- a/client-appimage-qt6/craftmaster.ini
+++ b/client-appimage-qt6/craftmaster.ini
@@ -3,7 +3,7 @@
 [General]
 Branch = master
 # CraftUrl = https://github.com/allexzander/craft.git
-CraftRevision = 7b73acd32984b67d7e1054c9a02e3d86eca9a030
+CraftRevision = d9d06ff743183104bc50698e376807976fa0e460
 ShallowClone = False
 
 # Variables defined here override the default value
@@ -36,15 +36,15 @@ Packager/CacheDir = ${Variables:Root}\cache
 [BlueprintSettings]
 nextcloud-client.buildTests = True
 binary/mysql.useMariaDB = False
-libs/qt6.version = 6.10.1
+libs/qt6.version = 6.10.2
 craft/craft-blueprints-kde.revision = master
 
 [linux-gcc-x86_64]
 General/ABI = linux-gcc-x86_64
 Paths/Python = /usr/bin/python3
 Packager/RepositoryUrl = https://files.kde.org/craft/Qt6/
-Packager/CacheVersion = 25.12
-libs/qt6.version = 6.10.1
+Packager/CacheVersion = 26.02
+libs/qt6.version = 6.10.2
 
 [Env]
 CRAFT_CODESIGN_CERTIFICATE =


### PR DESCRIPTION
QtWebEngine in 6.10.1 is faulty, resulting in a crash of the client when showing the account wizard