### PR TITLE
Change git push target from develop to main for iOS Notes

### DIFF
--- a/translations/handleiOSNotesTranslations.sh
+++ b/translations/handleiOSNotesTranslations.sh
@@ -47,5 +47,5 @@ mv Source/Settings.bundle/de_DE.lproj/Root.strings Source/Settings.bundle/de.lpr
 # create git commit and push it
 git add .
 git commit -am "fix(l10n): Update translations from Transifex" -s || true
-git push origin develop
+git push origin main
 echo "done"


### PR DESCRIPTION
`develop` will be removed from Notes, so the new target will be `main`