### PR TITLE
translations: add IntroVox

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -50,6 +50,7 @@
 				"nextcloud groupfolders",
 				"nextcloud guests",
 				"nextcloud impersonate",
+				"nextcloud IntroVox",
 				"nextcloud integration_discourse",
 				"nextcloud integration_documenso",
 				"nextcloud integration_docusign",


### PR DESCRIPTION
## Summary

Onboard [nextcloud/IntroVox](https://github.com/nextcloud/IntroVox) to the Transifex translation sync.

## Checklist

- [x] App repository contains [`.tx/config`](https://github.com/nextcloud/IntroVox/blob/main/.tx/config) pointing at `o:nextcloud:p:nextcloud:r:introvox`
- [x] App repository contains `l10n/.gitkeep`
- [x] App repository contains `.l10nignore`
- [x] `@nextcloud-bot` has admin access to nextcloud/IntroVox

## Context

Community member [@henmohr](https://github.com/henmohr) reported in nextcloud/IntroVox#16 that the `introvox` resource is not discoverable on Transifex. The app's `.tx/config` already declares the resource, but it was never registered with the sync bot here — this PR fixes that.

IntroVox is a Nextcloud app that provides a guided introduction wizard for new users. Source strings live in PHP templates (`templates/`), Vue components (`src/`), and the `appinfo/info.xml` description.