### PR TITLE
chore(shallow-server): Update to PHP 8.3 because master drops 8.2

### DIFF
--- a/shallow-server/Dockerfile
+++ b/shallow-server/Dockerfile
@@ -7,13 +7,13 @@ RUN apt-get update && \
     wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
     apt-get update && \
-    apt-get install -y php8.2-cli php8.2-common php8.2-mbstring \
-    php8.2-gd php8.2-imagick php8.2-intl php8.2-bz2 php8.2-xml \
-    php8.2-mysql php8.2-zip php8.2-dev curl php8.2-curl \
-    php-dompdf php8.2-apcu redis-server php8.2-redis php8.2-smbclient \
-    php8.2-ldap unzip php8.2-pgsql php8.2-sqlite make apache2 \
-    php8.2-opcache libmagickcore-6.q16-2-extra \
-    libapache2-mod-php8.2 php-pear libaio1 build-essential expect && \
+    apt-get install -y php8.3-cli php8.3-common php8.3-mbstring \
+    php8.3-gd php8.3-imagick php8.3-intl php8.3-bz2 php8.3-xml \
+    php8.3-mysql php8.3-zip php8.3-dev curl php8.3-curl \
+    php-dompdf php8.3-apcu redis-server php8.3-redis php8.3-smbclient \
+    php8.3-ldap unzip php8.3-pgsql php8.3-sqlite make apache2 \
+    php8.3-opcache libmagickcore-6.q16-2-extra \
+    libapache2-mod-php8.3 php-pear libaio1 build-essential expect && \
     apt-get autoremove -y && apt-get autoclean && apt-get clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
@@ -23,9 +23,9 @@ RUN chmod +x /tmp/oci8-setup.sh && \
     /tmp/oci8-setup.sh && \
     rm -f /tmp/oci8-setup.sh
 
-COPY apc-cli-enable.ini /etc/php/8.2/cli/conf.d/99-apc-cli-enable.ini
-COPY oci8-enable.ini /etc/php/8.2/apache2/conf.d/99-oci8-enable.ini
-COPY opcache-recommended.ini /etc/php/8.2/cli/conf.d/99-opcache-recommended.ini
+COPY apc-cli-enable.ini /etc/php/8.3/cli/conf.d/99-apc-cli-enable.ini
+COPY oci8-enable.ini /etc/php/8.3/apache2/conf.d/99-oci8-enable.ini
+COPY opcache-recommended.ini /etc/php/8.3/cli/conf.d/99-opcache-recommended.ini
 
 WORKDIR /var/www/html
 
@@ -51,7 +51,7 @@ ADD ssl/nextcloud.crt /etc/ssl/certs/nextcloud.crt
 ADD ssl/nextcloud.key /etc/ssl/private/nextcloud.key
 ADD ssl/default-ssl.conf /etc/apache2/sites-available/default-ssl.conf
 ADD default-nextcloud.conf /etc/apache2/sites-enabled/default-nextcloud.conf
-ADD nextcloud.ini /etc/php/8.2/apache2/conf.d/nextcloud.ini
+ADD nextcloud.ini /etc/php/8.3/apache2/conf.d/nextcloud.ini
 
 RUN chmod +x /usr/local/bin/*
 


### PR DESCRIPTION
For https://github.com/nextcloud/server/pull/61142

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
