### PR TITLE
Pull iOS stringdicts with default source

### DIFF
--- a/translations/handleiOSTranslations.sh
+++ b/translations/handleiOSTranslations.sh
@@ -32,7 +32,10 @@ git checkout -- Supporting\ Files/en.lproj
 tx push -s
 
 # pull translations
-tx pull -f -a
+tx pull -force -all
+
+# then, pull .stringdict translations, replace untranslated strings with source
+tx pull -force -all --mode sourceastranslation -resources o:nextcloud:p:nextcloud:r:ios-plurals
 
 cd Supporting\ Files
 


### PR DESCRIPTION
Pulled .stringdicts (containing singular/plural variations of sentences) from Transifex do not include a default string if not translated, resulting in no text being displayed at all on iOS. This resolves this by pulling the source (English) if a string is not translated.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
