### PR TITLE
Add nextcloud metavox to Transifex translation sync

### DIFF
--- a/translations/config.json
+++ b/translations/config.json
@@ -88,6 +88,7 @@
 				"nextcloud mail",
 				"nextcloud maps",
 				"nextcloud memegen",
+				"nextcloud metavox",
 				"nextcloud news",
 				"nextcloud nextcloud_announcements",
 				"nextcloud notes",


### PR DESCRIPTION
## Summary

Adds **`nextcloud metavox`** to the app translation sync list so the transifex-sync bot picks up [nextcloud/metavox](https://github.com/nextcloud/metavox).

MetaVox adds SharePoint-style metadata columns to Nextcloud Team/Group Folders (app id: `metavox`, ~430 translatable UI strings).

## Repository readiness

I'm preparing the `nextcloud/metavox` repo to match the standard sync requirements:

- [ ] `.tx/config` in PO form → resource `o:nextcloud:p:nextcloud:r:metavox`, `source_file = translationfiles/templates/metavox.pot`, `type = PO`
- [ ] `.l10nignore` in repo root
- [ ] `l10n/` folder present
- [ ] `@nextcloud-bot` granted write access to `nextcloud/metavox`

If anything else is needed before the initial sync (e.g. the resource currently exists as KEYVALUEJSON and should be re-created as PO), please let me know and I'll adjust. Happy to hold this until the repo side is fully in place.

Reference: same setup as the recently-added `nextcloud IntraVox`.