### PR TITLE
chore: Use 'sourceastranslation' for talk-ios plurals

### DIFF
--- a/translations/handleiOSTalkTranslations.sh
+++ b/translations/handleiOSTalkTranslations.sh
@@ -45,7 +45,11 @@ do
   git checkout -- NextcloudTalk/en.lproj
 
   # pull translations
-  tx pull -f -a --minimum-perc=25
+  tx pull --force --all --minimum-perc=25
+
+  # then, pull .stringdict translations, replace untranslated strings with source
+  # note: this is needed as the untranslated .stringdict files are not auto replaced by source
+  tx pull --force --all --mode sourceastranslation --resources nextcloud.talk-ios-plurals
 
   cd NextcloudTalk
 

--- a/translations/handleiOSTranslations.sh
+++ b/translations/handleiOSTranslations.sh
@@ -32,11 +32,11 @@ git checkout -- Supporting\ Files/en.lproj
 tx push -s
 
 # pull translations
-tx pull -force -all
+tx pull --force --all
 
 # then, pull .stringdict translations, replace untranslated strings with source
 # note: this is needed as the untranslated .stringdict files are not auto replaced by source
-tx pull -force -all --mode sourceastranslation -resources nextcloud.ios-plurals
+tx pull --force --all --mode sourceastranslation --resources nextcloud.ios-plurals
 
 cd Supporting\ Files
 


### PR DESCRIPTION
Copied what files ios is doing: https://github.com/nextcloud/docker-ci/blob/9e17ac5c180031ea08b58aae6587cdaa6392205e/translations/handleiOSTranslations.sh#L34-L39

No idea how to test it myself, though?!

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
